### PR TITLE
Fixes Clang 3.7 failure to compile.

### DIFF
--- a/src/cell.hpp
+++ b/src/cell.hpp
@@ -90,8 +90,11 @@ public:
         spike_detectors_(other.spike_detectors_),
         probes_(other.probes_)
      {
-        util::assign_by(segments_, other.segments_,
-            [](const segment_ptr& p) { return p->clone(); });
+         // unique_ptr's cannot be copy constructed, do a manual assignment
+         auto siter = segments_.begin();
+         for (const auto& s : other.segments_) {
+             *siter = std::move(s->clone());
+         }
      }
 
     /// add a soma to the cell

--- a/src/cell.hpp
+++ b/src/cell.hpp
@@ -242,4 +242,3 @@ cable_segment* cell::add_cable(cell::index_type parent, Args ...args)
 
 } // namespace mc
 } // namespace nest
-

--- a/src/util/rangeutil.hpp
+++ b/src/util/rangeutil.hpp
@@ -62,33 +62,9 @@ Container& append(Container &c, const Seq& seq) {
 // Assign sequence to a container
 
 template <typename AssignableContainer, typename Seq>
-enable_if_t<
-    std::is_copy_constructible<typename AssignableContainer::value_type>::value,
-    AssignableContainer&
->
-assign(AssignableContainer& c, const Seq& seq) {
+AssignableContainer& assign(AssignableContainer& c, const Seq& seq) {
     auto canon = canonical_view(seq);
     c.assign(std::begin(canon), std::end(canon));
-    return c;
-}
-
-
-// This version of assing is needed for assigning segment_ptr's (i.e.,
-// unique_ptr's) with Clang
-
-template<typename AssignableContainer, typename Seq>
-enable_if_t<
-    !std::is_copy_constructible<typename AssignableContainer::value_type>::value &&
-     std::is_move_constructible<typename AssignableContainer::value_type>::value,
-    AssignableContainer&
->
-assign(AssignableContainer& c, const Seq& seq)
-{
-    auto citer = c.begin();
-    for (auto s : canonical_view(seq)) {
-        *citer = std::move(s);
-    }
-
     return c;
 }
 


### PR DESCRIPTION
* Container assignment requires that the elements of the target container are copy constructible, whereas `unique_ptr`s in Clang 7.0 are only move constructible, which I believe it's the correct behaviour according to the standard, preventing `rangeutil.hpp` from compiling.
* Includes correct header (`<numeric>`) that provides `std::accumulate()`.