### PR TITLE
Address deprecated use of 'symbol' warning.

### DIFF
--- a/validation/ref/numeric/numeric_rallpack1.jl
+++ b/validation/ref/numeric/numeric_rallpack1.jl
@@ -55,9 +55,9 @@ trace = Dict(
     :units => "mV",
     :data => Dict(
         :time => map(t->t/ms, ts),
-        symbol("cable.x0.0") => map(v->v/mV, run_cable(0, ts)),
-        symbol("cable.x0.3") => map(v->v/mV, run_cable(0.3, ts)),
-        symbol("cable.x1.0") => map(v->v/mV, run_cable(1.0, ts))
+        Symbol("cable.x0.0") => map(v->v/mV, run_cable(0, ts)),
+        Symbol("cable.x0.3") => map(v->v/mV, run_cable(0.3, ts)),
+        Symbol("cable.x1.0") => map(v->v/mV, run_cable(1.0, ts))
     )
 )
 

--- a/validation/ref/numeric/numeric_soma.jl
+++ b/validation/ref/numeric/numeric_soma.jl
@@ -19,7 +19,7 @@ trace = Dict(
     :units => "mV",
     :data => Dict(
         :time => map(t->t/ms, ts),
-        symbol("soma.mid") => map(v->v/mV, vs)
+        Symbol("soma.mid") => map(v->v/mV, vs)
     )
 )
 


### PR DESCRIPTION
Julia 0.5 deprecates use of `symbol` instead of`Symbol`. This patch just substitutes the correct call.