### PR TITLE
Feature/gpu validation issue #68

### DIFF
--- a/modcc/cprinter.cpp
+++ b/modcc/cprinter.cpp
@@ -305,12 +305,9 @@ CPrinter::CPrinter(Module &m, bool o)
     //////////////////////////////////////////////
 
     auto proctest = [] (procedureKind k) {
-        return
-            k == procedureKind::normal
-                 || k == procedureKind::api
-                 || k == procedureKind::net_receive;
+        return is_in(k, {procedureKind::normal, procedureKind::api, procedureKind::net_receive});
     };
-    for(auto &var : m.symbols()) {
+    for(auto const& var: m.symbols()) {
         auto isproc = var.second->kind()==symbolKind::procedure;
         if(isproc )
         {
@@ -461,10 +458,6 @@ void CPrinter::visit(BlockExpression *e) {
             }
         }
         if(names.size()>0) {
-            //for(auto it=names.begin(); it!=names.end(); ++it) {
-            //    text_.add_gutter() << "value_type " << *it;
-            //    text_.end_line("{0};");
-            //}
             text_.add_gutter() << "value_type " << *(names.begin());
             for(auto it=names.begin()+1; it!=names.end(); ++it) {
                 text_ << ", " << *it;
@@ -498,8 +491,9 @@ void CPrinter::visit(IfExpression *e) {
     text_ << "}";
 }
 
+// NOTE: net_receive() is classified as a ProcedureExpression
 void CPrinter::visit(ProcedureExpression *e) {
-    // ------------- print prototype ------------- //
+    // print prototype
     text_.add_gutter() << "void " << e->name() << "(int i_";
     for(auto& arg : e->args()) {
         text_ << ", value_type " << arg->is_argument()->name();
@@ -518,19 +512,18 @@ void CPrinter::visit(ProcedureExpression *e) {
             e->location());
     }
 
+    // print body
     increase_indentation();
-
     e->body()->accept(this);
 
-    // ------------- close up ------------- //
+    // close the function body
     decrease_indentation();
     text_.add_line("}");
     text_.add_line();
-    return;
 }
 
 void CPrinter::visit(APIMethod *e) {
-    // ------------- print prototype ------------- //
+    // print prototype
     text_.add_gutter() << "void " << e->name() << "() override {";
     text_.end_line();
 
@@ -566,7 +559,7 @@ void CPrinter::visit(APIMethod *e) {
             }
         }
 
-        // ------------- get loop dimensions ------------- //
+        // get loop dimensions
         text_.add_line("int n_ = node_index_.size();");
 
         // hand off printing of loops to optimized or unoptimized backend
@@ -578,14 +571,12 @@ void CPrinter::visit(APIMethod *e) {
         }
     }
 
-    // ------------- close up ------------- //
+    // close up the loop body
     text_.add_line("}");
     text_.add_line();
 }
 
 void CPrinter::print_APIMethod_unoptimized(APIMethod* e) {
-    //text_.add_line("START_PROFILE");
-
     // there can not be more than 1 instance of a density channel per grid point,
     // so we can assert that aliasing will not occur.
     if(optimize_) text_.add_line("#pragma ivdep");

--- a/modcc/cprinter.hpp
+++ b/modcc/cprinter.hpp
@@ -44,6 +44,9 @@ public:
     void decrease_indentation(){
         text_.decrease_indentation();
     }
+    void clear_text() {
+        text_.clear();
+    }
 private:
 
     void print_APIMethod_optimized(APIMethod* e);

--- a/modcc/cudaprinter.cpp
+++ b/modcc/cudaprinter.cpp
@@ -129,12 +129,10 @@ CUDAPrinter::CUDAPrinter(Module &m, bool o)
 
         // print stubs that call API method kernels that are defined in the
         // kernels::name namespace
-        auto proctest = [] (procedureKind k) {
-            return is_in(k, {procedureKind::normal, procedureKind::api});
-        };
         for(auto const &var : m.symbols()) {
             if (var.second->kind()==symbolKind::procedure &&
-                proctest(var.second->is_procedure()->kind()))
+                is_in(var.second->is_procedure()->kind(),
+                      {procedureKind::normal, procedureKind::api}))
             {
                 var.second->accept(this);
             }

--- a/modcc/cudaprinter.cpp
+++ b/modcc/cudaprinter.cpp
@@ -412,11 +412,9 @@ CUDAPrinter::CUDAPrinter(Module &m, bool o)
 
     //////////////////////////////////////////////
     //////////////////////////////////////////////
-
-    auto proctest = [] (procedureKind k) {return k == procedureKind::api;};
     for(auto const &var : m.symbols()) {
         if( var.second->kind()==symbolKind::procedure && 
-            proctest(var.second->is_procedure()->kind()))
+            var.second->is_procedure()->kind()==procedureKind::api)
         {
             auto proc = var.second->is_api_method();
             auto name = proc->name();

--- a/modcc/cudaprinter.cpp
+++ b/modcc/cudaprinter.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 
+#include "cprinter.hpp" // needed for printing net_receive method
 #include "cudaprinter.hpp"
 #include "lexer.hpp"
 
@@ -114,27 +115,11 @@ CUDAPrinter::CUDAPrinter(Module &m, bool o)
         text_.decrease_indentation();
         text_.add_line("}");
         text_.add_line();
-        /*
-        text_.add_line("__device__");
-        text_.add_line("inline double atomicSub(double* address, double val) {");
-        text_.increase_indentation();
-        text_.add_line("return atomicAdd(address, -val);");
-        text_.decrease_indentation();
-        text_.add_line("}");
-        text_.add_line();
-        text_.add_line("__device__");
-        text_.add_line("inline float atomicSub(float* address, float val) {");
-        text_.increase_indentation();
-        text_.add_line("return atomicAdd(address, -val);");
-        text_.decrease_indentation();
-        text_.add_line("}");
-        text_.add_line();
-        */
 
         // forward declarations of procedures
         for(auto const &var : m.symbols()) {
-            if(   var.second->kind()==symbolKind::procedure
-            && var.second->is_procedure()->kind() == procedureKind::normal)
+            if( var.second->kind()==symbolKind::procedure &&
+                var.second->is_procedure()->kind() == procedureKind::normal)
             {
                 print_procedure_prototype(var.second->is_procedure());
                 text_.end_line(";");
@@ -144,8 +129,9 @@ CUDAPrinter::CUDAPrinter(Module &m, bool o)
 
         // print stubs that call API method kernels that are defined in the
         // kernels::name namespace
-        auto proctest = [] (procedureKind k) {return k == procedureKind::normal
-                                                  || k == procedureKind::api;   };
+        auto proctest = [] (procedureKind k) {
+            return is_in(k, {procedureKind::normal, procedureKind::api});
+        };
         for(auto const &var : m.symbols()) {
             if (var.second->kind()==symbolKind::procedure &&
                 proctest(var.second->is_procedure()->kind()))
@@ -431,8 +417,8 @@ CUDAPrinter::CUDAPrinter(Module &m, bool o)
 
     auto proctest = [] (procedureKind k) {return k == procedureKind::api;};
     for(auto const &var : m.symbols()) {
-        if(   var.second->kind()==symbolKind::procedure
-        && proctest(var.second->is_procedure()->kind()))
+        if( var.second->kind()==symbolKind::procedure && 
+            proctest(var.second->is_procedure()->kind()))
         {
             auto proc = var.second->is_api_method();
             auto name = proc->name();
@@ -446,6 +432,29 @@ CUDAPrinter::CUDAPrinter(Module &m, bool o)
             text_.add_line(
                 "kernels::" + name + "<value_type, size_type>"
                 + "<<<dim_grid, dim_block>>>(param_pack_);");
+            text_.decrease_indentation();
+            text_.add_line("}");
+            text_.add_line();
+        }
+        else if( var.second->kind()==symbolKind::procedure &&
+                 var.second->is_procedure()->kind()==procedureKind::net_receive)
+        {
+            auto proc = var.second->is_procedure();
+            auto name = proc->name();
+            text_.add_line("void " + name + "(int i_, value_type weight) {");
+            text_.increase_indentation();
+
+            // Print the body of the net_receive block.
+            // Use the same body as would be generated with the cprinter.
+            // This is not omptimal, because each read and write will require
+            // a copy between host and device memory, so we will need a
+            // GPU-specific implementation
+            auto cprinter = CPrinter(*module_);
+            cprinter.clear_text();
+            cprinter.set_gutter(text_.get_gutter());
+            proc->body()->accept(&cprinter);
+            text_ << cprinter.text();
+
             text_.decrease_indentation();
             text_.add_line("}");
             text_.add_line();
@@ -648,28 +657,26 @@ void CUDAPrinter::visit(ProcedureExpression *e) {
             e->location());
     }
 
-    // ------------- print prototype ------------- //
+    // print prototype
     print_procedure_prototype(e);
     text_.end_line(" {");
 
-    // ------------- print body ------------- //
+    // print body
     increase_indentation();
 
     text_.add_line("using value_type = T;");
-    text_.add_line("using iarray = I;");
     text_.add_line();
 
     e->body()->accept(this);
 
-    // ------------- close up ------------- //
+    // close up
     decrease_indentation();
     text_.add_line("}");
     text_.add_line();
-    return;
 }
 
 void CUDAPrinter::visit(APIMethod *e) {
-    // ------------- print prototype ------------- //
+    // print prototype
     text_.add_gutter() << "template <typename T, typename I>\n";
     text_.add_line(       "__global__");
     text_.add_gutter() << "void " << e->name()
@@ -702,7 +709,8 @@ void CUDAPrinter::visit(APIMethod *e) {
     text_.add_line("}");
 
     decrease_indentation();
-    text_.add_line("}\n");
+    text_.add_line("}");
+    text_.add_line();
 }
 
 void CUDAPrinter::print_APIMethod_body(APIMethod* e) {

--- a/modcc/lexer.cpp
+++ b/modcc/lexer.cpp
@@ -263,7 +263,7 @@ Token Lexer::number() {
         }
         else if(!uses_scientific_notation && (c=='e' || c=='E')) {
             if(is_numeric(current_[1]) ||
-               is_plusminus(current_[1]) && is_numeric(current_[2]))
+               (is_plusminus(current_[1]) && is_numeric(current_[2])))
             {
                 uses_scientific_notation++;
                 str += c;

--- a/modcc/textbuffer.cpp
+++ b/modcc/textbuffer.cpp
@@ -28,6 +28,9 @@ void TextBuffer::set_gutter(int width) {
     indent_ = width;
     gutter_ = std::string(indent_, ' ');
 }
+int TextBuffer::get_gutter() {
+    return indent_;
+}
 
 void TextBuffer::increase_indentation() {
     indent_ += indentation_width_;
@@ -46,4 +49,8 @@ void TextBuffer::decrease_indentation() {
 
 std::stringstream& TextBuffer::text() {
     return text_;
+}
+
+void TextBuffer::clear() {
+    text_.str("");
 }

--- a/modcc/textbuffer.hpp
+++ b/modcc/textbuffer.hpp
@@ -18,10 +18,13 @@ public:
     std::string str() const;
 
     void set_gutter(int width);
+    int get_gutter();
 
     void increase_indentation();
     void decrease_indentation();
     std::stringstream &text();
+
+    void clear();
 
 private:
 

--- a/src/backends/fvm_multicore.hpp
+++ b/src/backends/fvm_multicore.hpp
@@ -132,7 +132,7 @@ struct backend {
     static bool has_mechanism(const std::string& name) { return mech_map_.count(name)>0; }
 
     static std::string name() {
-        return "multicore";
+        return "cpu";
     }
 
 private:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,5 @@
 # google test framework
 add_library(gtest gtest-all.cpp)
-# tests look for gtest.h here
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-
 
 # Unit tests
 add_subdirectory(unit)

--- a/tests/global_communication/mpi_listener.hpp
+++ b/tests/global_communication/mpi_listener.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <cstdio>
-#include <ostream>
+#include <fstream>
 #include <stdexcept>
 
 #include <communication/global_policy.hpp>
 
-#include "gtest.h"
+#include "../gtest.h"
 
 /// A specialized listener desinged for printing test results with MPI.
 ///

--- a/tests/global_communication/test.cpp
+++ b/tests/global_communication/test.cpp
@@ -3,7 +3,7 @@
 #include <numeric>
 #include <vector>
 
-#include "gtest.h"
+#include "../gtest.h"
 
 #include "mpi_listener.hpp"
 

--- a/tests/global_communication/test_communicator.cpp
+++ b/tests/global_communication/test_communicator.cpp
@@ -1,4 +1,4 @@
-#include "gtest.h"
+#include "../gtest.h"
 
 #include <cstdio>
 #include <fstream>

--- a/tests/global_communication/test_exporter_spike_file.cpp
+++ b/tests/global_communication/test_exporter_spike_file.cpp
@@ -1,4 +1,4 @@
-#include "gtest.h"
+#include "../gtest.h"
 
 #include <cstdio>
 #include <fstream>

--- a/tests/global_communication/test_mpi_gather_all.cpp
+++ b/tests/global_communication/test_mpi_gather_all.cpp
@@ -1,6 +1,6 @@
-#include "gtest.h"
-
 #ifdef WITH_MPI
+
+#include "../gtest.h"
 
 #include <cstring>
 #include <vector>

--- a/tests/modcc/test.hpp
+++ b/tests/modcc/test.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <gtest.h>
+#include "../gtest.h"
 
 #include "parser.hpp"
 #include "modccutil.hpp"

--- a/tests/modcc/test_parser.cpp
+++ b/tests/modcc/test_parser.cpp
@@ -354,7 +354,7 @@ TEST(Parser, parse_stoich_expression) {
     for (auto& text: single_expr) {
         std::unique_ptr<StoichExpression> s;
         EXPECT_TRUE(check_parse(s, &Parser::parse_stoich_expression, text));
-        EXPECT_EQ(1, s->terms().size());
+        EXPECT_EQ(1u, s->terms().size());
     }
 
     const char* double_expr[] = {
@@ -364,7 +364,7 @@ TEST(Parser, parse_stoich_expression) {
     for (auto& text: double_expr) {
         std::unique_ptr<StoichExpression> s;
         EXPECT_TRUE(check_parse(s, &Parser::parse_stoich_expression, text));
-        EXPECT_EQ(2, s->terms().size());
+        EXPECT_EQ(2u, s->terms().size());
     }
 
     const char* other_good_expr[] = {
@@ -380,7 +380,7 @@ TEST(Parser, parse_stoich_expression) {
     {
         std::unique_ptr<StoichExpression> s;
         EXPECT_TRUE(check_parse(s, &Parser::parse_stoich_expression, check_coeff));
-        EXPECT_EQ(4, s->terms().size());
+        EXPECT_EQ(4u, s->terms().size());
         std::vector<int> confirm = {-3,2,-1,1};
         for (unsigned i = 0; i<4; ++i) {
             auto term = s->terms()[i]->is_stoich_term();
@@ -439,19 +439,19 @@ TEST(Parser, parse_conserve) {
     ASSERT_TRUE(check_parse(s, &Parser::parse_conserve_expression, text));
     EXPECT_TRUE(s->rhs()->is_number());
     ASSERT_TRUE(s->lhs()->is_stoich());
-    EXPECT_EQ(2, s->lhs()->is_stoich()->terms().size());
+    EXPECT_EQ(2u, s->lhs()->is_stoich()->terms().size());
 
     text = "CONSERVE a = 1.23e-2";
     ASSERT_TRUE(check_parse(s, &Parser::parse_conserve_expression, text));
     EXPECT_TRUE(s->rhs()->is_number());
     ASSERT_TRUE(s->lhs()->is_stoich());
-    EXPECT_EQ(1, s->lhs()->is_stoich()->terms().size());
+    EXPECT_EQ(1u, s->lhs()->is_stoich()->terms().size());
 
     text = "CONSERVE = 0";
     ASSERT_TRUE(check_parse(s, &Parser::parse_conserve_expression, text));
     EXPECT_TRUE(s->rhs()->is_number());
     ASSERT_TRUE(s->lhs()->is_stoich());
-    EXPECT_EQ(0, s->lhs()->is_stoich()->terms().size());
+    EXPECT_EQ(0u, s->lhs()->is_stoich()->terms().size());
 
     text = "CONSERVE -2a + b -c = foo*2.3-bar";
     ASSERT_TRUE(check_parse(s, &Parser::parse_conserve_expression, text));
@@ -459,7 +459,7 @@ TEST(Parser, parse_conserve) {
     ASSERT_TRUE(s->lhs()->is_stoich());
     {
         auto& terms = s->lhs()->is_stoich()->terms();
-        ASSERT_EQ(3, terms.size());
+        ASSERT_EQ(3u, terms.size());
         auto coeff = terms[0]->is_stoich_term()->coeff()->is_integer();
         ASSERT_TRUE(coeff);
         EXPECT_EQ(-2, coeff->integer_value());

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_CUDA_SOURCES
+    test_cell_group.cu
     test_matrix.cu
     test_vector.cu
 

--- a/tests/unit/test_cell_group.cu
+++ b/tests/unit/test_cell_group.cu
@@ -7,24 +7,24 @@
 
 #include "../test_common_cells.hpp"
 
+using namespace nest::mc;
+
 using fvm_cell =
-    nest::mc::fvm::fvm_multicell<nest::mc::gpu::backend>;
+    fvm::fvm_multicell<nest::mc::gpu::backend>;
 
 nest::mc::cell make_cell() {
     using namespace nest::mc;
 
-    nest::mc::cell cell = make_cell_ball_and_stick();
+    cell c = make_cell_ball_and_stick();
 
-    cell.add_detector({0, 0}, 0);
-    cell.segment(1)->set_compartments(101);
+    c.add_detector({0, 0}, 0);
+    c.segment(1)->set_compartments(101);
 
-    return cell;
+    return c;
 }
 
 TEST(cell_group, test)
 {
-    using namespace nest::mc;
-
     using cell_group_type = cell_group<fvm_cell>;
     auto group = cell_group_type{0, util::singleton_view(make_cell())};
 

--- a/tests/unit/test_cell_group.cu
+++ b/tests/unit/test_cell_group.cu
@@ -1,0 +1,36 @@
+#include "../gtest.h"
+
+#include <cell_group.hpp>
+#include <common_types.hpp>
+#include <fvm_multicell.hpp>
+#include <util/rangeutil.hpp>
+
+#include "../test_common_cells.hpp"
+
+using fvm_cell =
+    nest::mc::fvm::fvm_multicell<nest::mc::gpu::backend>;
+
+nest::mc::cell make_cell() {
+    using namespace nest::mc;
+
+    nest::mc::cell cell = make_cell_ball_and_stick();
+
+    cell.add_detector({0, 0}, 0);
+    cell.segment(1)->set_compartments(101);
+
+    return cell;
+}
+
+TEST(cell_group, test)
+{
+    using namespace nest::mc;
+
+    using cell_group_type = cell_group<fvm_cell>;
+    auto group = cell_group_type{0, util::singleton_view(make_cell())};
+
+    group.advance(50, 0.01);
+
+    // the model is expected to generate 4 spikes as a result of the
+    // fixed stimulus over 50 ms
+    EXPECT_EQ(4u, group.spikes().size());
+}

--- a/tests/unit/test_filter.cpp
+++ b/tests/unit/test_filter.cpp
@@ -1,5 +1,3 @@
-#include "gtest.h"
-
 #include <cstring>
 #include <list>
 
@@ -7,6 +5,8 @@
 #include <util/rangeutil.hpp>
 #include <util/filter.hpp>
 #include <util/transform.hpp>
+
+#include "../gtest.h"
 
 #include "common.hpp"
 

--- a/tests/validation/CMakeLists.txt
+++ b/tests/validation/CMakeLists.txt
@@ -13,27 +13,38 @@ set(VALIDATION_SOURCES
     validate.cpp
 )
 
+set(VALIDATION_CUDA_SOURCES
+    # unit tests
+    validate_soma.cu
+    validate_ball_and_stick.cu
+    validate_synapses.cu
+
+    # support code
+    validation_data.cpp
+    trace_analysis.cpp
+
+    # unit test driver
+    validate.cpp
+)
+
 if(VALIDATION_DATA_DIR)
     add_definitions("-DDATADIR=\"${VALIDATION_DATA_DIR}\"")
 endif()
-add_executable(validate.exe ${VALIDATION_SOURCES} ${HEADERS})
 
+add_executable(validate.exe ${VALIDATION_SOURCES})
 set(TARGETS validate.exe)
+
+if(WITH_CUDA)
+    cuda_add_executable(validate_cuda.exe ${VALIDATION_CUDA_SOURCES})
+    list(APPEND TARGETS validate_cuda.exe)
+    target_link_libraries(validate_cuda.exe LINK_PUBLIC gpu)
+endif()
+
 
 foreach(target ${TARGETS})
     target_link_libraries(${target} LINK_PUBLIC nestmc gtest)
 
-    if(WITH_TBB)
-        target_link_libraries(${target} LINK_PUBLIC ${TBB_LIBRARIES})
-    endif()
-
-    if(WITH_CUDA)
-        target_link_libraries(${target} LINK_PUBLIC ${CUDA_LIBRARIES})
-    endif()
-
-    if(WITH_UNWIND)
-        target_link_libraries(${target} LINK_PUBLIC ${UNWIND_LIBRARIES})
-    endif()
+    target_link_libraries(${target} LINK_PUBLIC ${EXTERNAL_LIBRARIES})
 
     if(WITH_MPI)
         target_link_libraries(${target} LINK_PUBLIC ${MPI_C_LIBRARIES})

--- a/tests/validation/convergence_test.hpp
+++ b/tests/validation/convergence_test.hpp
@@ -2,10 +2,11 @@
 
 #include <util/filter.hpp>
 #include <util/rangeutil.hpp>
+#include <cell.hpp>
 
 #include <json/json.hpp>
 
-#include "gtest.h"
+#include "../gtest.h"
 
 #include "trace_analysis.hpp"
 #include "validation_data.hpp"
@@ -84,7 +85,7 @@ public:
             const auto& trace = se.sampler.trace;
 
             // save trace
-            nlohmann::json trace_meta{meta_};
+            nlohmann::json trace_meta(meta_);
             trace_meta[param_name_] = p;
 
             g_trace_io.save_trace(label, trace, trace_meta);

--- a/tests/validation/tinyopt.hpp
+++ b/tests/validation/tinyopt.hpp
@@ -6,7 +6,7 @@
 #include <stdexcept>
 #include <string>
 
-#include "gtest.h"
+#include "../gtest.h"
 
 #include <communication/global_policy.hpp>
 

--- a/tests/validation/trace_analysis.cpp
+++ b/tests/validation/trace_analysis.cpp
@@ -4,7 +4,7 @@
 
 #include <json/json.hpp>
 
-#include "gtest.h"
+#include "../gtest.h"
 
 #include <math.hpp>
 #include <simple_sampler.hpp>

--- a/tests/validation/trace_analysis.hpp
+++ b/tests/validation/trace_analysis.hpp
@@ -2,7 +2,7 @@
 
 #include <vector>
 
-#include "gtest.h"
+#include "../gtest.h"
 
 #include <simple_sampler.hpp>
 #include <math.hpp>

--- a/tests/validation/validate.cpp
+++ b/tests/validation/validate.cpp
@@ -4,9 +4,9 @@
 #include <string>
 #include <exception>
 
-#include "gtest.h"
-
 #include <communication/global_policy.hpp>
+
+#include "../gtest.h"
 
 #include "tinyopt.hpp"
 #include "validation_data.hpp"

--- a/tests/validation/validate_ball_and_stick.cu
+++ b/tests/validation/validate_ball_and_stick.cu
@@ -3,7 +3,7 @@
 
 #include <fvm_multicell.hpp>
 
-using lowered_cell = nest::mc::fvm::fvm_multicell<nest::mc::multicore::backend>;
+using lowered_cell = nest::mc::fvm::fvm_multicell<nest::mc::gpu::backend>;
 
 TEST(ball_and_stick, neuron_ref) {
     validate_ball_and_stick<lowered_cell>();

--- a/tests/validation/validate_ball_and_stick.hpp
+++ b/tests/validation/validate_ball_and_stick.hpp
@@ -1,0 +1,157 @@
+#include <json/json.hpp>
+
+#include <cell.hpp>
+#include <common_types.hpp>
+#include <fvm_multicell.hpp>
+#include <model.hpp>
+#include <recipe.hpp>
+#include <simple_sampler.hpp>
+#include <util/path.hpp>
+
+#include "../gtest.h"
+
+#include "../test_common_cells.hpp"
+#include "convergence_test.hpp"
+#include "trace_analysis.hpp"
+#include "validation_data.hpp"
+
+using namespace nest::mc;
+
+template <
+    typename LoweredCell,
+    typename SamplerInfoSeq
+>
+void run_ncomp_convergence_test(
+    const char* model_name,
+    const util::path& ref_data_path,
+    const cell& c,
+    SamplerInfoSeq& samplers,
+    float t_end=100.f)
+{
+    auto max_ncomp = g_trace_io.max_ncomp();
+    auto dt = g_trace_io.min_dt();
+
+    nlohmann::json meta = {
+        {"name", "membrane voltage"},
+        {"model", model_name},
+        {"dt", dt},
+        {"sim", "nestmc"},
+        {"units", "mV"},
+        {"backend", LoweredCell::backend::name()}
+    };
+
+    auto exclude = stimulus_ends(c);
+
+    convergence_test_runner<int> runner("ncomp", samplers, meta);
+    runner.load_reference_data(ref_data_path);
+
+    for (int ncomp = 10; ncomp<max_ncomp; ncomp*=2) {
+        for (auto& seg: c.segments()) {
+            if (!seg->is_soma()) {
+                seg->set_compartments(ncomp);
+            }
+        }
+        model<LoweredCell> m(singleton_recipe{c});
+
+        runner.run(m, ncomp, t_end, dt, exclude);
+    }
+    runner.report();
+    runner.assert_all_convergence();
+}
+
+
+template <typename LoweredCell>
+void validate_ball_and_stick() {
+    cell c = make_cell_ball_and_stick();
+    add_common_voltage_probes(c);
+
+    float sample_dt = 0.025f;
+    sampler_info samplers[] = {
+        {"soma.mid", {0u, 0u}, simple_sampler(sample_dt)},
+        {"dend.mid", {0u, 1u}, simple_sampler(sample_dt)},
+        {"dend.end", {0u, 2u}, simple_sampler(sample_dt)}
+    };
+
+    run_ncomp_convergence_test<LoweredCell>(
+        "ball_and_stick",
+        "neuron_ball_and_stick.json",
+        c,
+        samplers);
+}
+
+template <typename LoweredCell>
+void validate_ball_and_3stick() {
+    cell c = make_cell_ball_and_3stick();
+    add_common_voltage_probes(c);
+
+    float sample_dt = 0.025f;
+    sampler_info samplers[] = {
+        {"soma.mid",  {0u, 0u}, simple_sampler(sample_dt)},
+        {"dend1.mid", {0u, 1u}, simple_sampler(sample_dt)},
+        {"dend1.end", {0u, 2u}, simple_sampler(sample_dt)},
+        {"dend2.mid", {0u, 3u}, simple_sampler(sample_dt)},
+        {"dend2.end", {0u, 4u}, simple_sampler(sample_dt)},
+        {"dend3.mid", {0u, 5u}, simple_sampler(sample_dt)},
+        {"dend3.end", {0u, 6u}, simple_sampler(sample_dt)}
+    };
+
+    run_ncomp_convergence_test<LoweredCell>(
+        "ball_and_3stick",
+        "neuron_ball_and_3stick.json",
+        c,
+        samplers);
+}
+
+template <typename LoweredCell>
+void validate_rallpack1() {
+    cell c = make_cell_simple_cable();
+
+    // three probes: left end, 30% along, right end.
+    c.add_probe({{1, 0.0}, probeKind::membrane_voltage});
+    c.add_probe({{1, 0.3}, probeKind::membrane_voltage});
+    c.add_probe({{1, 1.0}, probeKind::membrane_voltage});
+
+    float sample_dt = 0.025f;
+    sampler_info samplers[] = {
+        {"cable.x0.0", {0u, 0u}, simple_sampler(sample_dt)},
+        {"cable.x0.3", {0u, 1u}, simple_sampler(sample_dt)},
+        {"cable.x1.0", {0u, 2u}, simple_sampler(sample_dt)},
+    };
+
+    run_ncomp_convergence_test<LoweredCell>(
+        "rallpack1",
+        "numeric_rallpack1.json",
+        c,
+        samplers,
+        250.f);
+}
+
+template <typename LoweredCell>
+void validate_ball_and_squiggle() {
+    cell c = make_cell_ball_and_squiggle();
+    add_common_voltage_probes(c);
+
+    float sample_dt = 0.025f;
+    sampler_info samplers[] = {
+        {"soma.mid", {0u, 0u}, simple_sampler(sample_dt)},
+        {"dend.mid", {0u, 1u}, simple_sampler(sample_dt)},
+        {"dend.end", {0u, 2u}, simple_sampler(sample_dt)}
+    };
+
+#if 0
+    // *temporarily* disabled: compartment division policy will
+    // be moved into backend policy classes.
+
+    run_ncomp_convergence_test<lowered_cell_div<div_compartment_sampler>>(
+        "ball_and_squiggle_sampler",
+        "neuron_ball_and_squiggle.json",
+        c,
+        samplers);
+#endif
+
+    run_ncomp_convergence_test<LoweredCell>(
+        "ball_and_squiggle_integrator",
+        "neuron_ball_and_squiggle.json",
+        c,
+        samplers);
+}

--- a/tests/validation/validate_ball_and_stick.hpp
+++ b/tests/validation/validate_ball_and_stick.hpp
@@ -15,19 +15,19 @@
 #include "trace_analysis.hpp"
 #include "validation_data.hpp"
 
-using namespace nest::mc;
-
 template <
     typename LoweredCell,
     typename SamplerInfoSeq
 >
 void run_ncomp_convergence_test(
     const char* model_name,
-    const util::path& ref_data_path,
-    const cell& c,
+    const nest::mc::util::path& ref_data_path,
+    const nest::mc::cell& c,
     SamplerInfoSeq& samplers,
     float t_end=100.f)
 {
+    using namespace nest::mc;
+
     auto max_ncomp = g_trace_io.max_ncomp();
     auto dt = g_trace_io.min_dt();
 
@@ -62,6 +62,8 @@ void run_ncomp_convergence_test(
 
 template <typename LoweredCell>
 void validate_ball_and_stick() {
+    using namespace nest::mc;
+
     cell c = make_cell_ball_and_stick();
     add_common_voltage_probes(c);
 
@@ -81,6 +83,8 @@ void validate_ball_and_stick() {
 
 template <typename LoweredCell>
 void validate_ball_and_3stick() {
+    using namespace nest::mc;
+
     cell c = make_cell_ball_and_3stick();
     add_common_voltage_probes(c);
 
@@ -104,6 +108,8 @@ void validate_ball_and_3stick() {
 
 template <typename LoweredCell>
 void validate_rallpack1() {
+    using namespace nest::mc;
+
     cell c = make_cell_simple_cable();
 
     // three probes: left end, 30% along, right end.
@@ -128,6 +134,8 @@ void validate_rallpack1() {
 
 template <typename LoweredCell>
 void validate_ball_and_squiggle() {
+    using namespace nest::mc;
+
     cell c = make_cell_ball_and_squiggle();
     add_common_voltage_probes(c);
 

--- a/tests/validation/validate_compartment_policy.cpp
+++ b/tests/validation/validate_compartment_policy.cpp
@@ -11,7 +11,7 @@
 #include <simple_sampler.hpp>
 #include <util/rangeutil.hpp>
 
-#include "gtest.h"
+#include "../gtest.h"
 
 #include "../test_common_cells.hpp"
 #include "../test_util.hpp"

--- a/tests/validation/validate_soma.cpp
+++ b/tests/validation/validate_soma.cpp
@@ -1,61 +1,9 @@
-#include <fstream>
-#include <utility>
-
-#include <json/json.hpp>
-
-#include <common_types.hpp>
-#include <cell.hpp>
-#include <fvm_multicell.hpp>
-#include <model.hpp>
-#include <recipe.hpp>
-#include <simple_sampler.hpp>
-#include <util/rangeutil.hpp>
+#include "validate_soma.hpp"
 
 #include "../gtest.h"
 
-#include "../test_common_cells.hpp"
-#include "convergence_test.hpp"
-#include "trace_analysis.hpp"
-#include "validation_data.hpp"
-
-using namespace nest::mc;
+using lowered_cell = nest::mc::fvm::fvm_multicell<multicore::backend>;
 
 TEST(soma, numeric_ref) {
-    using lowered_cell = fvm::fvm_multicell<multicore::backend>;
-
-    cell c = make_cell_soma_only();
-    add_common_voltage_probes(c);
-    model<lowered_cell> m(singleton_recipe{c});
-
-    float sample_dt = .025f;
-    sampler_info samplers[] = {{"soma.mid", {0u, 0u}, simple_sampler(sample_dt)}};
-
-    nlohmann::json meta = {
-        {"name", "membrane voltage"},
-        {"model", "soma"},
-        {"sim", "nestmc"},
-        {"units", "mV"}
-    };
-
-    convergence_test_runner<float> R("dt", samplers, meta);
-    R.load_reference_data("numeric_soma.json");
-
-    float t_end = 100.f;
-
-    // use dt = 0.05, 0.025, 0.01, 0.005, 0.0025,  ...
-    double max_oo_dt = std::round(1.0/g_trace_io.min_dt());
-    for (double base = 100; ; base *= 10) {
-        for (double multiple: {5., 2.5, 1.}) {
-            double oo_dt = base/multiple;
-            if (oo_dt>max_oo_dt) goto end;
-
-            m.reset();
-            float dt = float(1./oo_dt);
-            R.run(m, dt, t_end, dt);
-        }
-    }
-end:
-
-    R.report();
-    R.assert_all_convergence();
+    validate_soma<lowered_cell>();
 }

--- a/tests/validation/validate_soma.cpp
+++ b/tests/validation/validate_soma.cpp
@@ -2,7 +2,7 @@
 
 #include "../gtest.h"
 
-using lowered_cell = nest::mc::fvm::fvm_multicell<multicore::backend>;
+using lowered_cell = nest::mc::fvm::fvm_multicell<nest::mc::multicore::backend>;
 
 TEST(soma, numeric_ref) {
     validate_soma<lowered_cell>();

--- a/tests/validation/validate_soma.cu
+++ b/tests/validation/validate_soma.cu
@@ -1,61 +1,9 @@
-#include <fstream>
-#include <utility>
-
-#include <json/json.hpp>
-
-#include <common_types.hpp>
-#include <cell.hpp>
-#include <fvm_multicell.hpp>
-#include <model.hpp>
-#include <recipe.hpp>
-#include <simple_sampler.hpp>
-#include <util/rangeutil.hpp>
+#include "validate_soma.hpp"
 
 #include "../gtest.h"
 
-#include "../test_common_cells.hpp"
-#include "convergence_test.hpp"
-#include "trace_analysis.hpp"
-#include "validation_data.hpp"
-
-using namespace nest::mc;
+using lowered_cell = nest::mc::fvm::fvm_multicell<nest::mc::gpu::backend>;
 
 TEST(soma, numeric_ref) {
-    using lowered_cell = fvm::fvm_multicell<gpu::backend>;
-
-    cell c = make_cell_soma_only();
-    add_common_voltage_probes(c);
-    model<lowered_cell> m(singleton_recipe{c});
-
-    float sample_dt = .025f;
-    sampler_info samplers[] = {{"soma.mid", {0u, 0u}, simple_sampler(sample_dt)}};
-
-    nlohmann::json meta = {
-        {"name", "membrane voltage"},
-        {"model", "soma"},
-        {"sim", "nestmc"},
-        {"units", "mV"}
-    };
-
-    convergence_test_runner<float> runner("dt", samplers, meta);
-    runner.load_reference_data("numeric_soma.json");
-
-    float t_end = 100.f;
-
-    // use dt = 0.05, 0.025, 0.01, 0.005, 0.0025,  ...
-    double max_oo_dt = std::round(1.0/g_trace_io.min_dt());
-    for (double base = 100; ; base *= 10) {
-        for (double multiple: {5., 2.5, 1.}) {
-            double oo_dt = base/multiple;
-            if (oo_dt>max_oo_dt) goto end;
-
-            m.reset();
-            float dt = float(1./oo_dt);
-            runner.run(m, dt, t_end, dt);
-        }
-    }
-end:
-
-    runner.report();
-    runner.assert_all_convergence();
+    validate_soma<lowered_cell>();
 }

--- a/tests/validation/validate_soma.cu
+++ b/tests/validation/validate_soma.cu
@@ -1,0 +1,61 @@
+#include <fstream>
+#include <utility>
+
+#include <json/json.hpp>
+
+#include <common_types.hpp>
+#include <cell.hpp>
+#include <fvm_multicell.hpp>
+#include <model.hpp>
+#include <recipe.hpp>
+#include <simple_sampler.hpp>
+#include <util/rangeutil.hpp>
+
+#include "../gtest.h"
+
+#include "../test_common_cells.hpp"
+#include "convergence_test.hpp"
+#include "trace_analysis.hpp"
+#include "validation_data.hpp"
+
+using namespace nest::mc;
+
+TEST(soma, numeric_ref) {
+    using lowered_cell = fvm::fvm_multicell<gpu::backend>;
+
+    cell c = make_cell_soma_only();
+    add_common_voltage_probes(c);
+    model<lowered_cell> m(singleton_recipe{c});
+
+    float sample_dt = .025f;
+    sampler_info samplers[] = {{"soma.mid", {0u, 0u}, simple_sampler(sample_dt)}};
+
+    nlohmann::json meta = {
+        {"name", "membrane voltage"},
+        {"model", "soma"},
+        {"sim", "nestmc"},
+        {"units", "mV"}
+    };
+
+    convergence_test_runner<float> runner("dt", samplers, meta);
+    runner.load_reference_data("numeric_soma.json");
+
+    float t_end = 100.f;
+
+    // use dt = 0.05, 0.025, 0.01, 0.005, 0.0025,  ...
+    double max_oo_dt = std::round(1.0/g_trace_io.min_dt());
+    for (double base = 100; ; base *= 10) {
+        for (double multiple: {5., 2.5, 1.}) {
+            double oo_dt = base/multiple;
+            if (oo_dt>max_oo_dt) goto end;
+
+            m.reset();
+            float dt = float(1./oo_dt);
+            runner.run(m, dt, t_end, dt);
+        }
+    }
+end:
+
+    runner.report();
+    runner.assert_all_convergence();
+}

--- a/tests/validation/validate_soma.hpp
+++ b/tests/validation/validate_soma.hpp
@@ -13,10 +13,10 @@
 #include "trace_analysis.hpp"
 #include "validation_data.hpp"
 
-using namespace nest::mc;
-
 template <typename LoweredCell>
 void validate_soma() {
+    using namespace nest::mc;
+
     cell c = make_cell_soma_only();
     add_common_voltage_probes(c);
     model<LoweredCell> model(singleton_recipe{c});

--- a/tests/validation/validate_soma.hpp
+++ b/tests/validation/validate_soma.hpp
@@ -1,0 +1,56 @@
+#include <json/json.hpp>
+
+#include <common_types.hpp>
+#include <cell.hpp>
+#include <fvm_multicell.hpp>
+#include <model.hpp>
+#include <recipe.hpp>
+#include <simple_sampler.hpp>
+#include <util/rangeutil.hpp>
+
+#include "../test_common_cells.hpp"
+#include "convergence_test.hpp"
+#include "trace_analysis.hpp"
+#include "validation_data.hpp"
+
+using namespace nest::mc;
+
+template <typename LoweredCell>
+void validate_soma() {
+    cell c = make_cell_soma_only();
+    add_common_voltage_probes(c);
+    model<LoweredCell> model(singleton_recipe{c});
+
+    float sample_dt = .025f;
+    sampler_info samplers[] = {{"soma.mid", {0u, 0u}, simple_sampler(sample_dt)}};
+
+    nlohmann::json meta = {
+        {"name", "membrane voltage"},
+        {"model", "soma"},
+        {"sim", "nestmc"},
+        {"units", "mV"},
+        {"backend", LoweredCell::backend::name()}
+    };
+
+    convergence_test_runner<float> runner("dt", samplers, meta);
+    runner.load_reference_data("numeric_soma.json");
+
+    float t_end = 100.f;
+
+    // use dt = 0.05, 0.025, 0.01, 0.005, 0.0025,  ...
+    double max_oo_dt = std::round(1.0/g_trace_io.min_dt());
+    for (double base = 100; ; base *= 10) {
+        for (double multiple: {5., 2.5, 1.}) {
+            double oo_dt = base/multiple;
+            if (oo_dt>max_oo_dt) goto end;
+
+            model.reset();
+            float dt = float(1./oo_dt);
+            runner.run(model, dt, t_end, dt);
+        }
+    }
+end:
+
+    runner.report();
+    runner.assert_all_convergence();
+}

--- a/tests/validation/validate_synapses.cu
+++ b/tests/validation/validate_synapses.cu
@@ -3,7 +3,7 @@
 #include "../gtest.h"
 #include "validate_synapses.hpp"
 
-using lowered_cell = nest::mc::fvm::fvm_multicell<nest::mc::multicore::backend>;
+using lowered_cell = nest::mc::fvm::fvm_multicell<nest::mc::gpu::backend>;
 
 TEST(simple_synapse, expsyn_neuron_ref) {
     SCOPED_TRACE("expsyn");

--- a/tests/validation/validate_synapses.hpp
+++ b/tests/validation/validate_synapses.hpp
@@ -1,0 +1,70 @@
+#include <json/json.hpp>
+
+#include <cell.hpp>
+#include <cell_group.hpp>
+#include <fvm_multicell.hpp>
+#include <model.hpp>
+#include <recipe.hpp>
+#include <simple_sampler.hpp>
+#include <util/path.hpp>
+
+#include "../gtest.h"
+
+#include "../test_common_cells.hpp"
+#include "convergence_test.hpp"
+#include "trace_analysis.hpp"
+#include "validation_data.hpp"
+
+template <typename LoweredCell>
+void run_synapse_test(
+    const char* syn_type,
+    const nest::mc::util::path& ref_data_path,
+    float t_end=70.f,
+    float dt=0.001)
+{
+    using namespace nest::mc;
+
+    auto max_ncomp = g_trace_io.max_ncomp();
+    nlohmann::json meta = {
+        {"name", "membrane voltage"},
+        {"model", syn_type},
+        {"sim", "nestmc"},
+        {"units", "mV"},
+        {"backend", LoweredCell::backend::name()}
+    };
+
+    cell c = make_cell_ball_and_stick(false); // no stimuli
+    parameter_list syn_default(syn_type);
+    c.add_synapse({1, 0.5}, syn_default);
+    add_common_voltage_probes(c);
+
+    // injected spike events
+    postsynaptic_spike_event<float> synthetic_events[] = {
+        {{0u, 0u}, 10.0, 0.04},
+        {{0u, 0u}, 20.0, 0.04},
+        {{0u, 0u}, 40.0, 0.04}
+    };
+
+    // exclude points of discontinuity from linf analysis
+    std::vector<float> exclude = {10.f, 20.f, 40.f};
+
+    float sample_dt = 0.025f;
+    sampler_info samplers[] = {
+        {"soma.mid", {0u, 0u}, simple_sampler(sample_dt)},
+        {"dend.mid", {0u, 1u}, simple_sampler(sample_dt)},
+        {"dend.end", {0u, 2u}, simple_sampler(sample_dt)}
+    };
+
+    convergence_test_runner<int> runner("ncomp", samplers, meta);
+    runner.load_reference_data(ref_data_path);
+
+    for (int ncomp = 10; ncomp<max_ncomp; ncomp*=2) {
+        c.cable(1)->set_compartments(ncomp);
+        model<LoweredCell> m(singleton_recipe{c});
+        m.group(0).enqueue_events(synthetic_events);
+
+        runner.run(m, ncomp, t_end, dt, exclude);
+    }
+    runner.report();
+    runner.assert_all_convergence();
+}


### PR DESCRIPTION
feature: #67

The GPU branch is compiling and generating numerically stable results, however the miniapp is not generating spikes. This task will aim to reproduce correct results on the GPU.

The following steps were performed:
1. reproduce the hh-soma validation test on GPU
  * this is the simplest spot to start because it does not require events and doesn't have spatial terms
  * ensure that voltage and current updates are correctly implemented
2. reproduce the ball and stick model on GPU
3. reproduce miniapp spike chains
  * ensure that the spike detection and deliver works on GPU

Add cell_group unit test to the cuda unit tests
* builds simple ball and stick model and integrates
  for 50ms and records how many spikes occur
* is a simple early warning that something is broken
  * no substitute for the validation tests

Update the validate_soma, validate_ball_and_stick and
validate_synapses validation tests for gpu
* refactor indivudual tests into test runner functions
  that are templated on lowered cell type
* for each of the original validation tests we now have
  a cuda (.cu) and c++ (.cpp) implementation
* add additional "backend" meta data to the validation
  output (either "gpu" or "cpu")
* the soma and ball_and_stick validation passes
* the synapses validation fails due to lack of net_receive
  on gpu mechanism implementations

The CUDA back end was using the default net_receive implementation,
which was a "nop". This is why event based simulations were not
validating on the GPU.
* use a CPrinter to generate the same net_receive block that is
  used for the multicore backend. This is not efficient, because
  each read/write requires a cudamemcpy between host and device
  memory, however it allows us to pass all unit and validation tests.
* A more efficient GPU-specific implementation is left for later
  optimization work.

fixes #68 