### PR TITLE
fix modcc bug printing else branches

### DIFF
--- a/data/test.mod
+++ b/data/test.mod
@@ -59,9 +59,27 @@ PROCEDURE trates(v) {
     minf=1-1/(1+exp((v-vhalfm)/km))
     hinf=1/(1+exp((v-vhalfh)/kh))
 
+    if(minf<0) {
+        foo1()
+    }
+    else if (hinf<0) {
+        foo2()
+    }
+    else {
+        foo3()
+    }
+
+    if(minf>=m) {
+        foo3()
+    }
+
     mtau = 0.6
     htau = 1500
 }
+
+PROCEDURE foo1() {}
+PROCEDURE foo2() {}
+PROCEDURE foo3() {}
 
 : the 'states' in the definition is giving the derivative a name
 : this name is then used in the SOLVE statement above

--- a/modcc/cprinter.cpp
+++ b/modcc/cprinter.cpp
@@ -473,7 +473,9 @@ void CPrinter::visit(BlockExpression *e) {
         // these all must be handled
         text_.add_gutter();
         stmt->accept(this);
-        text_.end_line(";");
+        if (not stmt->is_if()) {
+            text_.end_line(";");
+        }
     }
 }
 
@@ -487,8 +489,24 @@ void CPrinter::visit(IfExpression *e) {
     increase_indentation();
     e->true_branch()->accept(this);
     decrease_indentation();
-    text_.add_gutter();
-    text_ << "}";
+    text_.add_line("}");
+    // check if there is a false-branch, i.e. if
+    // there is an "else" branch to print
+    if (auto fb = e->false_branch()) {
+        text_.add_gutter() << "else ";
+        // use recursion for "else if"
+        if (fb->is_if()) {
+            fb->accept(this);
+        }
+        // otherwise print the "else" block
+        else {
+            text_ << "{\n";
+            increase_indentation();
+            fb->accept(this);
+            decrease_indentation();
+            text_.add_line("}");
+        }
+    }
 }
 
 // NOTE: net_receive() is classified as a ProcedureExpression

--- a/modcc/cudaprinter.cpp
+++ b/modcc/cudaprinter.cpp
@@ -614,7 +614,9 @@ void CUDAPrinter::visit(BlockExpression *e) {
         // these all must be handled
         text_.add_gutter();
         stmt->accept(this);
-        text_.end_line(";");
+        if (not stmt->is_if()) {
+            text_.end_line(";");
+        }
     }
 }
 
@@ -628,8 +630,24 @@ void CUDAPrinter::visit(IfExpression *e) {
     increase_indentation();
     e->true_branch()->accept(this);
     decrease_indentation();
-    text_.add_gutter();
-    text_ << "}";
+    text_.add_line("}");
+    // check if there is a false-branch, i.e. if
+    // there is an "else" branch to print
+    if (auto fb = e->false_branch()) {
+        text_.add_gutter() << "else ";
+        // use recursion for "else if"
+        if (fb->is_if()) {
+            fb->accept(this);
+        }
+        // otherwise print the "else" block
+        else {
+            text_ << "{\n";
+            increase_indentation();
+            fb->accept(this);
+            decrease_indentation();
+            text_.add_line("}");
+        }
+    }
 }
 
 void CUDAPrinter::print_procedure_prototype(ProcedureExpression *e) {


### PR DESCRIPTION
fixes #90

The c and cuda printer were not printing else branches in if else
statements.
* added logic for printing else branches
* added if-else expressions to data/test.mod

No unit tests were added because we don't currently have a unit
testing framework for the output mechanisms.