### PR TITLE
Bug/issue#97

### DIFF
--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -5,6 +5,17 @@ set(CXXOPT_PTHREAD "-pthread")
 set(CXXOPT_CXX11 "-std=c++11")
 set(CXXOPT_WALL "-Wall")
 
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "XL")
+    # Disable 'missing-braces' warning: this will inappropriately
+    # flag initializations such as
+    #     std::array<int,3> a={1,2,3};
+
+    set(CXXOPT_WALL "${CXXOPT_WALL} -Wno-missing-braces")
+
+    # CMake, bless its soul, likes to insert this unsupported flag. Hilarity ensues.
+    string(REPLACE "-qhalt=e" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+endif()
+
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     # Disable 'missing-braces' warning: this will inappropriately
     # flag initializations such as

--- a/modcc/lexer.cpp
+++ b/modcc/lexer.cpp
@@ -23,7 +23,7 @@ inline bool is_whitespace(char c) {
     return (c==' ' || c=='\t' || c=='\v' || c=='\f');
 }
 inline bool is_eof(char c) {
-    return (c==0 || c==EOF);
+    return (c==0);
 }
 inline bool is_operator(char c) {
     return (c=='+' || c=='-' || c=='*' || c=='/' || c=='^' || c=='\'');
@@ -47,7 +47,6 @@ Token Lexer::parse() {
         switch(*current_) {
             // end of file
             case 0      :       // end of string
-            case EOF    :       // end of file
                 t.spelling = "eof";
                 t.type = tok::eof;
                 return t;

--- a/src/threading/pss_common.h
+++ b/src/threading/pss_common.h
@@ -51,8 +51,8 @@ void serial_destroy( RandomAccessIterator zs, RandomAccessIterator ze ) {
 template<class RandomAccessIterator1, class RandomAccessIterator2, class RandomAccessIterator3, class Compare>
 void serial_move_merge( RandomAccessIterator1 xs, RandomAccessIterator1 xe, RandomAccessIterator2 ys, RandomAccessIterator2 ye, RandomAccessIterator3 zs, Compare comp ) {
     if( xs!=xe ) {
-        if( ys!=ye )
-            for(;;)
+        if( ys!=ye ) {
+            for(;;) {
                 if( comp(*ys,*xs) ) {
                     *zs = std::move(*ys);
                     ++zs;
@@ -62,6 +62,8 @@ void serial_move_merge( RandomAccessIterator1 xs, RandomAccessIterator1 xe, Rand
                     ++zs;
                     if( ++xs==xe ) goto movey;
                 }
+            }
+        }
         ys = xs;
         ye = xe;
     }

--- a/tests/unit/test_uninitialized.cpp
+++ b/tests/unit/test_uninitialized.cpp
@@ -150,9 +150,11 @@ TEST(uninitialized,apply) {
 
     const uninitialized<int> ud(ua);
 
-    r=ud.apply(A);
+    //asm volatile("" ::: "memory");
+
     EXPECT_EQ(12,ua.cref());
     EXPECT_EQ(12,ud.cref());
+    r=ud.apply(A);
     EXPECT_EQ(13,r);
 
     EXPECT_EQ(2,A.op_count);

--- a/tests/unit/test_uninitialized.cpp
+++ b/tests/unit/test_uninitialized.cpp
@@ -150,11 +150,10 @@ TEST(uninitialized,apply) {
 
     const uninitialized<int> ud(ua);
 
-    //asm volatile("" ::: "memory");
+    r=ud.apply(A);
 
     EXPECT_EQ(12,ua.cref());
     EXPECT_EQ(12,ud.cref());
-    r=ud.apply(A);
     EXPECT_EQ(13,r);
 
     EXPECT_EQ(2,A.op_count);

--- a/tests/validation/convergence_test.hpp
+++ b/tests/validation/convergence_test.hpp
@@ -71,7 +71,7 @@ public:
     }
 
     template <typename Model>
-    void run(Model& m, Param p, float t_end, float dt, const std::vector<float>& excl={}) {
+    void run(Model& m, Param p, float t_end, float dt, const std::vector<float>& excl) {
         // reset samplers and attach to probe locations
         for (auto& se: cell_samplers_) {
             se.sampler.reset();

--- a/tests/validation/validate_soma.hpp
+++ b/tests/validation/validate_soma.hpp
@@ -46,7 +46,7 @@ void validate_soma() {
 
             model.reset();
             float dt = float(1./oo_dt);
-            runner.run(model, dt, t_end, dt);
+            runner.run(model, dt, t_end, dt, {});
         }
     }
 end:


### PR DESCRIPTION
This addresses all of the compiler warnings and errors for xlc when compiled at `-O0`. There are still compiler bugs when compiling with higher optimization levels, however they are more challenging.

* ignore the incorrect `-Wno-missing-braces` warnings (similarly to Clang)
* remove `-qhalt=e` flag inserted by CMake
* remove redundant comparison of `char` to `EOF` in lexer
* The XLC compiler was crashing inexplicably on one call of the following method
    `void run(..., const std::vector<float>& excl={}) {...}`
  This was fixed by not having a default value for the last argument.
*  add some curly braces to silence warning for dangling else

fixes #97