### PR TITLE
Add initializer_list version for is_in in modccutil.hpp

### DIFF
--- a/modcc/modccutil.hpp
+++ b/modcc/modccutil.hpp
@@ -4,10 +4,21 @@
 #include <memory>
 #include <sstream>
 #include <vector>
+#include <initializer_list>
 
 // is thing in list?
 template <typename T, int N>
 bool is_in(T thing, const T (&list)[N]) {
+    for(auto const& item : list) {
+        if(thing==item) {
+            return true;
+        }
+    }
+    return false;
+}
+
+template <typename T>
+bool is_in(T thing, const std::initializer_list<T> list) {
     for(auto const& item : list) {
         if(thing==item) {
             return true;


### PR DESCRIPTION
is_in was templated on (T thing, const T (&list)[N])
which fails to match an initializer list on clang-3.7.1
as in is_in(a, {procedureKind::...)

templating on (T thing, std::initializer_list<T> list)
works on clang, and continues to work on gcc.