### PR TITLE
Link external libs in global_communication test

### DIFF
--- a/tests/global_communication/CMakeLists.txt
+++ b/tests/global_communication/CMakeLists.txt
@@ -18,10 +18,6 @@ foreach(target ${TARGETS})
     target_link_libraries(${target} LINK_PUBLIC nestmc gtest)
     target_link_libraries(${target} LINK_PUBLIC ${EXTERNAL_LIBRARIES})
 
-    if(WITH_TBB)
-        target_link_libraries(${target} LINK_PUBLIC ${TBB_LIBRARIES})
-    endif()
-
     if(WITH_MPI)
         target_link_libraries(${target} LINK_PUBLIC ${MPI_C_LIBRARIES})
         set_property(TARGET ${target} APPEND_STRING PROPERTY LINK_FLAGS "${MPI_C_LINK_FLAGS}")

--- a/tests/global_communication/CMakeLists.txt
+++ b/tests/global_communication/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TARGETS global_communication.exe)
 
 foreach(target ${TARGETS})
     target_link_libraries(${target} LINK_PUBLIC nestmc gtest)
+    target_link_libraries(${target} LINK_PUBLIC ${EXTERNAL_LIBRARIES})
 
     if(WITH_TBB)
         target_link_libraries(${target} LINK_PUBLIC ${TBB_LIBRARIES})


### PR DESCRIPTION
* Add `target_link_libraries` for external libs in `tests/global_communication/CMakeLists.txt`.

Fixes issue #132