### PR TITLE
fix warnings from tests and link failer for perf test

### DIFF
--- a/tests/performance/io/CMakeLists.txt
+++ b/tests/performance/io/CMakeLists.txt
@@ -8,10 +8,7 @@ set(DISK_IO_SOURCES
 add_executable(disk_io.exe ${DISK_IO_SOURCES} ${HEADERS})
 
 target_link_libraries(disk_io.exe LINK_PUBLIC nestmc)
-
-if(WITH_TBB)
-    target_link_libraries(disk_io.exe LINK_PUBLIC ${TBB_LIBRARIES})
-endif()
+target_link_libraries(disk_io.exe LINK_PUBLIC ${EXTERNAL_LIBRARIES})
 
 if(WITH_MPI)
     target_link_libraries(disk_io.exe LINK_PUBLIC ${MPI_C_LIBRARIES})

--- a/tests/unit/test_mechanisms.cpp
+++ b/tests/unit/test_mechanisms.cpp
@@ -52,7 +52,7 @@ TEST(mechanisms, helpers) {
 
 // Setup and update mechanism
 template<typename T>
-void mech_update(T* mech, int num_iters) {
+void mech_update(T* mech, unsigned num_iters) {
 
     using namespace nest::mc;
     std::map<mechanisms::ionKind, mechanisms::ion<typename T::backend>> ions;
@@ -78,11 +78,11 @@ void mech_update(T* mech, int num_iters) {
         }
     }
 
-    for (auto i = 0; i < mech->node_index_.size(); ++i) {
+    for (auto i=0u; i<mech->node_index_.size(); ++i) {
         mech->net_receive(i, 1.);
     }
 
-    for (auto i = 0; i < num_iters; ++i) {
+    for (auto i=0u; i<num_iters; ++i) {
         mech->nrn_current();
         mech->nrn_state();
     }


### PR DESCRIPTION
* fix signed-vs-unsigned warning in mechanisms unit test
* fix linking error caused by out of date linkage description in CMake for the performance test