### PR TITLE
Fix a few compilation problems that occur when using c++14 mode

### DIFF
--- a/modcc/functionexpander.cpp
+++ b/modcc/functionexpander.cpp
@@ -5,6 +5,8 @@
 #include "functionexpander.hpp"
 #include "modccutil.hpp"
 
+using namespace nest::mc;
+
 expression_ptr insert_unique_local_assignment(call_list_type& stmts, Expression* e) {
     auto exprs = make_unique_local_assign(e->scope(), e);
     stmts.push_front(std::move(exprs.local_decl));
@@ -18,7 +20,7 @@ expression_ptr insert_unique_local_assignment(call_list_type& stmts, Expression*
 
 call_list_type lower_function_calls(Expression* e)
 {
-    auto v = make_unique<FunctionCallLowerer>(e->scope());
+    auto v = util::make_unique<FunctionCallLowerer>(e->scope());
 
     if(auto a=e->is_assignment()) {
 #ifdef LOGGING

--- a/modcc/functioninliner.cpp
+++ b/modcc/functioninliner.cpp
@@ -5,6 +5,8 @@
 #include "modccutil.hpp"
 #include "errorvisitor.hpp"
 
+using namespace nest::mc;
+
 expression_ptr inline_function_call(Expression* e)
 {
     if(auto f=e->is_function_call()) {
@@ -34,7 +36,7 @@ expression_ptr inline_function_call(Expression* e)
                           << " in the expression " << new_e->to_string() << "\n";
 #endif
                 auto v =
-                    make_unique<VariableReplacer>(
+                    util::make_unique<VariableReplacer>(
                         fargs[i]->is_argument()->spelling(),
                         id->spelling()
                     );
@@ -47,7 +49,7 @@ expression_ptr inline_function_call(Expression* e)
                           << " in the expression " << new_e->to_string() << "\n";
 #endif
                 auto v =
-                    make_unique<ValueInliner>(
+                    util::make_unique<ValueInliner>(
                         fargs[i]->is_argument()->spelling(),
                         value->value()
                     );
@@ -62,7 +64,7 @@ expression_ptr inline_function_call(Expression* e)
         }
         new_e->semantic(e->scope());
 
-        auto v = make_unique<ErrorVisitor>("");
+        auto v = util::make_unique<ErrorVisitor>("");
         new_e->accept(v.get());
 #ifdef LOGGING
         std::cout << "inline_function_call result " << new_e->to_string() << "\n\n";

--- a/modcc/modcc.cpp
+++ b/modcc/modcc.cpp
@@ -13,6 +13,8 @@
 #include "modccutil.hpp"
 #include "options.hpp"
 
+using namespace nest::mc;
+
 //#define VERBOSE
 
 int main(int argc, char **argv) {
@@ -173,13 +175,13 @@ int main(int argc, char **argv) {
                     std::cout << yellow("method " + method->name()) << "\n";
                     std::cout << white("-------------------------\n");
 
-                    auto flops = make_unique<FlopVisitor>();
+                    auto flops = util::make_unique<FlopVisitor>();
                     method->accept(flops.get());
                     std::cout << white("FLOPS") << std::endl;
                     std::cout << flops->print() << std::endl;
 
                     std::cout << white("MEMOPS") << std::endl;
-                    auto memops = make_unique<MemOpVisitor>();
+                    auto memops = util::make_unique<MemOpVisitor>();
                     method->accept(memops.get());
                     std::cout << memops->print() << std::endl;;
                 }

--- a/modcc/modccutil.hpp
+++ b/modcc/modccutil.hpp
@@ -138,9 +138,16 @@ std::ostream& operator<< (std::ostream& os, std::vector<T> const& V) {
     return os << "]";
 }
 
+namespace nest {
+namespace mc {
+namespace util {
+
 // just because we aren't using C++14, doesn't mean we shouldn't go
 // without make_unique
 template <typename T, typename... Args>
 std::unique_ptr<T> make_unique(Args&&... args) {
     return std::unique_ptr<T>(new T(std::forward<Args>(args) ...));
 }
+
+}}}
+

--- a/modcc/module.cpp
+++ b/modcc/module.cpp
@@ -11,6 +11,8 @@
 #include "module.hpp"
 #include "parser.hpp"
 
+using namespace nest::mc;
+
 Module::Module(std::string const& fname)
 : fname_(fname)
 {
@@ -163,7 +165,7 @@ bool Module::semantic() {
             s->semantic(symbols_);
 
             // then use an error visitor to print out all the semantic errors
-            auto v = make_unique<ErrorVisitor>(file_name());
+            auto v = util::make_unique<ErrorVisitor>(file_name());
             s->accept(v.get());
             errors += v->num_errors();
 
@@ -427,7 +429,7 @@ bool Module::semantic() {
                         }
                         else {
                             // create visitor for linear analysis
-                            auto v = make_unique<ExpressionClassifierVisitor>(sym);
+                            auto v = util::make_unique<ExpressionClassifierVisitor>(sym);
                             rhs->accept(v.get());
 
                             // quit if ODE is not linear
@@ -529,9 +531,9 @@ bool Module::semantic() {
                 auto rhs = e->is_assignment()->rhs();
 
                 // analyze the expression for linear terms
-                //auto v = make_unique<ExpressionClassifierVisitor>(symbols_["v"].get());
+                //auto v = util::make_unique<ExpressionClassifierVisitor>(symbols_["v"].get());
                 auto v_symbol = breakpoint->scope()->find("v");
-                auto v = make_unique<ExpressionClassifierVisitor>(v_symbol);
+                auto v = util::make_unique<ExpressionClassifierVisitor>(v_symbol);
                 rhs->accept(v.get());
 
                 if(v->classify()==expressionClassification::linear) {
@@ -555,7 +557,7 @@ bool Module::semantic() {
             block.emplace_back(Parser("current_ = weights_ * current_").parse_line_expression());
         }
 
-        auto v = make_unique<ConstantFolderVisitor>();
+        auto v = util::make_unique<ConstantFolderVisitor>();
         for(auto& e : block) {
             e->accept(v.get());
         }
@@ -780,7 +782,7 @@ bool Module::optimize() {
     // how to structure the optimizer
     // loop over APIMethods
     //      - apply optimization to each in turn
-    auto folder = make_unique<ConstantFolderVisitor>();
+    auto folder = util::make_unique<ConstantFolderVisitor>();
     for(auto &symbol : symbols_) {
         auto kind = symbol.second->kind();
         BlockExpression* body;

--- a/src/ion.hpp
+++ b/src/ion.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
+#include <array>
 #include <memory/memory.hpp>
-
 #include <indexed_view.hpp>
 
 namespace nest {

--- a/src/util/cycle.hpp
+++ b/src/util/cycle.hpp
@@ -191,8 +191,8 @@ template <
     typename = enable_if_t<std::is_same<SeqIter, SeqSentinel>::value>
 >
 range<cyclic_iterator<SeqIter, SeqSentinel> > cyclic_view(const Seq& s) {
-    return { make_cyclic_iterator(cbegin(s), cend(s)),
-             make_cyclic_iterator(cend(s), cend(s)) };
+    return { make_cyclic_iterator(util::cbegin(s), util::cend(s)),
+             make_cyclic_iterator(util::cend(s), util::cend(s)) };
 }
 
 template <
@@ -203,7 +203,7 @@ template <
 >
 range<cyclic_iterator<SeqIter, SeqSentinel>, SeqSentinel>
 cyclic_view(const Seq& s) {
-    return { make_cyclic_iterator(cbegin(s), cend(s)), cend(s) };
+    return { make_cyclic_iterator(util::cbegin(s), util::cend(s)), util::cend(s) };
 }
 
 // Handle initializer lists
@@ -211,8 +211,8 @@ template <typename T>
 range<cyclic_iterator<typename std::initializer_list<T>::const_iterator,
                       typename std::initializer_list<T>::const_iterator> >
 cyclic_view(const std::initializer_list<T> &list) {
-    return { make_cyclic_iterator(cbegin(list), cend(list)),
-             make_cyclic_iterator(cend(list), cend(list)) };
+    return { make_cyclic_iterator(util::cbegin(list), util::cend(list)),
+             make_cyclic_iterator(util::cend(list), util::cend(list)) };
 }
 
 } // namespace util

--- a/src/util/filter.hpp
+++ b/src/util/filter.hpp
@@ -209,8 +209,8 @@ template <
 >
 range<filter_iterator<seq_citer, seq_citer, util::decay_t<F>>>
 filter(const Seq& s, const F& f) {
-    return {make_filter_iterator(cbegin(s), cend(s), f),
-            make_filter_iterator(cend(s), cend(s), f)};
+    return {make_filter_iterator(util::cbegin(s), util::cend(s), f),
+            make_filter_iterator(util::cend(s), util::cend(s), f)};
 }
 
 // filter over const and non-const sentinel-terminated sequences:
@@ -236,7 +236,7 @@ template <
 >
 range<filter_iterator<seq_citer, seq_csent, util::decay_t<F>>, seq_csent>
 filter(const Seq& s, const F& f) {
-    return {make_filter_iterator(cbegin(s), cend(s), f), cend(s)};
+    return {make_filter_iterator(util::cbegin(s), util::cend(s), f), util::cend(s)};
 }
 
 } // namespace util

--- a/src/util/meta.hpp
+++ b/src/util/meta.hpp
@@ -58,14 +58,14 @@ constexpr bool empty(const T (& c)[N]) noexcept {
 template <typename Seq>
 struct sequence_traits {
     using iterator = decltype(std::begin(std::declval<Seq&>()));
-    using const_iterator = decltype(cbegin(std::declval<Seq&>()));
+    using const_iterator = decltype(util::cbegin(std::declval<Seq&>()));
     using value_type = typename std::iterator_traits<iterator>::value_type;
     using reference = typename std::iterator_traits<iterator>::reference;
     using difference_type = typename std::iterator_traits<iterator>::difference_type;
     using size_type = decltype(size(std::declval<Seq&>()));
     // for use with heterogeneous ranges
     using sentinel = decltype(std::end(std::declval<Seq&>()));
-    using const_sentinel = decltype(cend(std::declval<Seq&>()));
+    using const_sentinel = decltype(util::cend(std::declval<Seq&>()));
 };
 
 // Convenience short cuts for `enable_if`

--- a/src/util/transform.hpp
+++ b/src/util/transform.hpp
@@ -117,7 +117,7 @@ template <
 >
 range<transform_iterator<seq_citer, util::decay_t<F>>>
 transform_view(const Seq& s, const F& f) {
-    return {make_transform_iterator(cbegin(s), f), make_transform_iterator(cend(s), f)};
+    return {make_transform_iterator(util::cbegin(s), f), make_transform_iterator(util::cend(s), f)};
 }
 
 template <
@@ -129,7 +129,7 @@ template <
 >
 range<transform_iterator<seq_citer, util::decay_t<F>>, seq_csent>
 transform_view(const Seq& s, const F& f) {
-    return {make_transform_iterator(cbegin(s), f), cend(s)};
+    return {make_transform_iterator(util::cbegin(s), f), util::cend(s)};
 }
 
 } // namespace util

--- a/tests/modcc/test_kinetic_rewriter.cpp
+++ b/tests/modcc/test_kinetic_rewriter.cpp
@@ -48,7 +48,7 @@ static const char* derivative_abc =
     "}                         \n";
 
 TEST(KineticRewriter, equiv) {
-    auto visitor = make_unique<KineticRewriter>();
+    auto visitor = util::make_unique<KineticRewriter>();
     auto kin = Parser(kinetic_abc).parse_procedure();
     auto deriv = Parser(derivative_abc).parse_procedure();
 

--- a/tests/modcc/test_optimization.cpp
+++ b/tests/modcc/test_optimization.cpp
@@ -6,7 +6,7 @@
 #include "modccutil.hpp"
 
 TEST(Optimizer, constant_folding) {
-    auto v = make_unique<ConstantFolderVisitor>();
+    auto v = util::make_unique<ConstantFolderVisitor>();
     {
         auto e = parse_line_expression("x = 2*3");
         VERBOSE_PRINT( e->to_string() );

--- a/tests/modcc/test_visitors.cpp
+++ b/tests/modcc/test_visitors.cpp
@@ -12,56 +12,56 @@
 
 TEST(FlopVisitor, basic) {
     {
-    auto visitor = make_unique<FlopVisitor>();
+    auto visitor = util::make_unique<FlopVisitor>();
     auto e = parse_expression("x+y");
     e->accept(visitor.get());
     EXPECT_EQ(visitor->flops.add, 1);
     }
 
     {
-    auto visitor = make_unique<FlopVisitor>();
+    auto visitor = util::make_unique<FlopVisitor>();
     auto e = parse_expression("x-y");
     e->accept(visitor.get());
     EXPECT_EQ(visitor->flops.add, 1);
     }
 
     {
-    auto visitor = make_unique<FlopVisitor>();
+    auto visitor = util::make_unique<FlopVisitor>();
     auto e = parse_expression("x*y");
     e->accept(visitor.get());
     EXPECT_EQ(visitor->flops.mul, 1);
     }
 
     {
-    auto visitor = make_unique<FlopVisitor>();
+    auto visitor = util::make_unique<FlopVisitor>();
     auto e = parse_expression("x/y");
     e->accept(visitor.get());
     EXPECT_EQ(visitor->flops.div, 1);
     }
 
     {
-    auto visitor = make_unique<FlopVisitor>();
+    auto visitor = util::make_unique<FlopVisitor>();
     auto e = parse_expression("exp(x)");
     e->accept(visitor.get());
     EXPECT_EQ(visitor->flops.exp, 1);
     }
 
     {
-    auto visitor = make_unique<FlopVisitor>();
+    auto visitor = util::make_unique<FlopVisitor>();
     auto e = parse_expression("log(x)");
     e->accept(visitor.get());
     EXPECT_EQ(visitor->flops.log, 1);
     }
 
     {
-    auto visitor = make_unique<FlopVisitor>();
+    auto visitor = util::make_unique<FlopVisitor>();
     auto e = parse_expression("cos(x)");
     e->accept(visitor.get());
     EXPECT_EQ(visitor->flops.cos, 1);
     }
 
     {
-    auto visitor = make_unique<FlopVisitor>();
+    auto visitor = util::make_unique<FlopVisitor>();
     auto e = parse_expression("sin(x)");
     e->accept(visitor.get());
     EXPECT_EQ(visitor->flops.sin, 1);
@@ -70,7 +70,7 @@ TEST(FlopVisitor, basic) {
 
 TEST(FlopVisitor, compound) {
     {
-        auto visitor = make_unique<FlopVisitor>();
+        auto visitor = util::make_unique<FlopVisitor>();
     auto e = parse_expression("x+y*z/a-b");
     e->accept(visitor.get());
     EXPECT_EQ(visitor->flops.add, 2);
@@ -79,7 +79,7 @@ TEST(FlopVisitor, compound) {
     }
 
     {
-        auto visitor = make_unique<FlopVisitor>();
+        auto visitor = util::make_unique<FlopVisitor>();
     auto e = parse_expression("exp(x+y+z)");
     e->accept(visitor.get());
     EXPECT_EQ(visitor->flops.add, 2);
@@ -87,7 +87,7 @@ TEST(FlopVisitor, compound) {
     }
 
     {
-        auto visitor = make_unique<FlopVisitor>();
+        auto visitor = util::make_unique<FlopVisitor>();
     auto e = parse_expression("exp(x+y) + 3/(12 + z)");
     e->accept(visitor.get());
     EXPECT_EQ(visitor->flops.add, 3);
@@ -97,7 +97,7 @@ TEST(FlopVisitor, compound) {
 
     // test asssignment expression
     {
-        auto visitor = make_unique<FlopVisitor>();
+        auto visitor = util::make_unique<FlopVisitor>();
     auto e = parse_line_expression("x = exp(x+y) + 3/(12 + z)");
     e->accept(visitor.get());
     EXPECT_EQ(visitor->flops.add, 3);
@@ -117,7 +117,7 @@ TEST(FlopVisitor, procedure) {
 "    mtau = 0.6\n"
 "    htau = 1500\n"
 "}";
-    auto visitor = make_unique<FlopVisitor>();
+    auto visitor = util::make_unique<FlopVisitor>();
     auto e = parse_procedure(expression);
     e->accept(visitor.get());
     EXPECT_EQ(visitor->flops.add, 6);
@@ -139,7 +139,7 @@ TEST(FlopVisitor, function) {
 "    hinf=1/(1+exp((v-vhalfh)/kh))\n"
 "    foo = minf + hinf\n"
 "}";
-    auto visitor = make_unique<FlopVisitor>();
+    auto visitor = util::make_unique<FlopVisitor>();
     auto e = parse_function(expression);
     e->accept(visitor.get());
     EXPECT_EQ(visitor->flops.add, 7);


### PR DESCRIPTION
make_unique has been moved into nest:mc::util namespace to avoid a conflict with std::make_unique
util:: cbegin and cend clash with std:: equivalents, so we call them by namespace explicitly.