### PR TITLE
Some fixes for running modcc when the backend and frontend are dfifferent

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ cmake <path to CMakeLists.txt> -DCMAKE_BUILD_TYPE=release
 make -j8
 
 # set path and test that you can see modcc
-export PATH=`pwd`/bin:$PATH
+export PATH=`pwd`/modcc:$PATH
 which modcc
 ```
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,10 @@ add_subdirectory(global_communication)
 add_subdirectory(performance)
 
 # modcc tests
-add_subdirectory(modcc)
+if(NOT use_external_modcc)
+    add_subdirectory(modcc)
+endif()
+
 
 # Proposed additional test types:
 


### PR DESCRIPTION
Includes a fix to the readme which applies to any external modcc, and a way to keep from rebuilding locally an external modcc.
