### PR TITLE
remove small cudaMemcpys

### DIFF
--- a/src/backends/fvm_gpu.hpp
+++ b/src/backends/fvm_gpu.hpp
@@ -122,12 +122,13 @@ struct backend {
 
             // make a copy of the conductance on the host
             host_array face_conductance_tmp = face_conductance;
+            auto p_tmp = memory::on_host(p);
             for(auto i: util::make_span(1u, n)) {
                 auto gij = face_conductance_tmp[i];
 
                 u_tmp[i] = -gij;
                 invariant_d_tmp[i] += gij;
-                invariant_d_tmp[p[i]] += gij;
+                invariant_d_tmp[p_tmp[i]] += gij;
             }
             invariant_d = invariant_d_tmp;
             memory::copy(u_tmp, u);

--- a/src/backends/fvm_gpu.hpp
+++ b/src/backends/fvm_gpu.hpp
@@ -118,17 +118,19 @@ struct backend {
         {
             auto n = d.size();
             host_array invariant_d_tmp(n, 0);
+            host_array u_tmp(n, 0);
 
             // make a copy of the conductance on the host
             host_array face_conductance_tmp = face_conductance;
             for(auto i: util::make_span(1u, n)) {
                 auto gij = face_conductance_tmp[i];
 
-                u[i] = -gij;
+                u_tmp[i] = -gij;
                 invariant_d_tmp[i] += gij;
                 invariant_d_tmp[p[i]] += gij;
             }
             invariant_d = invariant_d_tmp;
+            memory::copy(u_tmp, u);
 
             params = {
                 d.data(), u.data(), rhs.data(),

--- a/src/cell_group.hpp
+++ b/src/cell_group.hpp
@@ -106,7 +106,7 @@ public:
             time_type tnext = next ? next->time: tstep;
             cell_.advance(tnext - cell_.time());
 
-            if (!cell_.is_physical_solution()) {
+            if (util::is_debug_mode() && !cell_.is_physical_solution()) {
                 std::cerr << "warning: solution out of bounds for cell "
                           << gid_base_ << " at t " << cell_.time() << " ms\n";
             }

--- a/src/util/debug.hpp
+++ b/src/util/debug.hpp
@@ -11,6 +11,13 @@ namespace nest {
 namespace mc {
 namespace util {
 
+constexpr inline bool is_debug_mode() {
+#ifndef NDEBUG
+    return true;
+#else
+    return false;
+#endif
+}
 using failed_assertion_handler_t =
     bool (*)(const char* assertion, const char* file, int line, const char* func);
 


### PR DESCRIPTION
This patch removes the many small `cudaMemcpy` calls for single values, except for those from calling `net_receive` in event delivery.

The small copies during initialization were from when the upper diagonal and time invariant component of the diagonal were computed on the host. There were many small reads/writes to device memory accessing the `p` and `u` vectors.
  * removed by making host-side copies, and copying the result to the device en masse where appropriate

I also added a `constexpr` function for testing if compiled in debug mode, and use that to only perform the `is_physical_solution` test when compiled in debug mode. This test causes a single memcopy on each time step to test whether the voltage has exceeded some "reasonable" beounds.