### PR TITLE
Base report generation `makefile` on `latexmk`.

### DIFF
--- a/docs/model/images/makefile
+++ b/docs/model/images/makefile
@@ -1,7 +1,14 @@
-all : cable.pdf soma.pdf
+.PHONY: all
 
-cable.pdf : cable.tex
-	pdflatex cable.tex
+sources := cable.tex soma.tex
 
-soma.pdf : soma.tex
-	pdflatex soma.tex
+all: $(patsubst %.tex,%.pdf,$(sources))
+
+LATEXMK := latexmk -pdf -halt-on-error
+
+%.pdf: %.tex
+	$(LATEXMK) $<
+
+clean:
+	for s in $(sources); do $(LATEXMK) -C "$$s"; done
+

--- a/docs/model/makefile
+++ b/docs/model/makefile
@@ -1,21 +1,13 @@
-report.pdf : *.tex images.dir bib
-	pdflatex report.tex
+images := images/cable.pdf images/soma.pdf
 
-images.dir:
-	make -C images
+LATEXMK := latexmk -e '$$clean_ext=q/bbl run.xml/' -pdf -use-make -halt-on-error
 
-force : report.pdf
-	pdflatex report.tex
+report.pdf : report.tex appendix.tex formulation.tex symbols.tex SelfArx.cls bibliography.bib ${images}
+	$(LATEXMK) $<
 
-bib : *.tex bibliography.bib
-	pdflatex report.tex
-	bibtex report
-	pdflatex report.tex
-	pdflatex report.tex
+images/%.pdf: images/%.tex
+	make -C images $(patsubst images/%,%,$@)
 
-clean :
-	rm -f *.pdf
-	rm -f *.log
-	rm -f *.out
-	rm -f *.aux
-	rm -f *.toc
+clean:
+	$(LATEXMK) -C report.tex
+	make -C images clean    

--- a/docs/model/report.bbl
+++ b/docs/model/report.bbl
@@ -1,9 +1,0 @@
-\begin{thebibliography}{1}
-
-\bibitem{lindsay_2004}
-K.~Lindsay, J.~Rosenberg, and G.~Tucker.
-\newblock From maxwell's equations to the cable equation and beyond.
-\newblock {\em Progress in Biophysics and Molecular Biology}, 85(1):71 -- 116,
-  2004.
-
-\end{thebibliography}


### PR DESCRIPTION
Using `latexmk` simplifies the `makefile` structure and avoids many of the problems with redundant `pdflatex` invocation.

* Rewrite `docs/model/makefile` and `docs/model/images/makefile` to use `latexmk` for building and cleaning.
* Remove generated `report.bbl` from repo.