### PR TITLE
Allow explicit make of GPU mechanisms.

### DIFF
--- a/mechanisms/CMakeLists.txt
+++ b/mechanisms/CMakeLists.txt
@@ -20,15 +20,13 @@ build_modules(
     TARGET build_all_mods
 )
 
-if(NMC_WITH_CUDA)
-    set(mech_dir "${CMAKE_CURRENT_SOURCE_DIR}/gpu")
-    file(MAKE_DIRECTORY "${mech_dir}")
-    build_modules(
-        ${mechanisms}
-        SOURCE_DIR "${mod_srcdir}"
-        DEST_DIR "${mech_dir}"
-        MODCC_FLAGS -t gpu ${modcc_opt}
-        TARGET build_all_gpu_mods
-    )
-endif()
+set(mech_dir "${CMAKE_CURRENT_SOURCE_DIR}/gpu")
+file(MAKE_DIRECTORY "${mech_dir}")
+build_modules(
+    ${mechanisms}
+    SOURCE_DIR "${mod_srcdir}"
+    DEST_DIR "${mech_dir}"
+    MODCC_FLAGS -t gpu ${modcc_opt}
+    TARGET build_all_gpu_mods
+)
 


### PR DESCRIPTION
When `NMC_WITH_CUDA` is off, still allow the generation of CUDA mechanisms with `modcc` by exposing the `build_all_gpu_mods` target; this can be performed independently of the presence (or otherwise) of a CUDA development environment. Building them can be done with an explicit `make build_all_gpu_mods`.

This eases development of GPU-related modcc tasks, as preliminary work can be performed and checked on machines without a CUDA environment.