### PR TITLE
Simple `net_receive` device kenels

### DIFF
--- a/mechanisms/CMakeLists.txt
+++ b/mechanisms/CMakeLists.txt
@@ -20,15 +20,13 @@ build_modules(
     TARGET build_all_mods
 )
 
-if(NMC_WITH_CUDA)
-    set(mech_dir "${CMAKE_CURRENT_SOURCE_DIR}/gpu")
-    file(MAKE_DIRECTORY "${mech_dir}")
-    build_modules(
-        ${mechanisms}
-        SOURCE_DIR "${mod_srcdir}"
-        DEST_DIR "${mech_dir}"
-        MODCC_FLAGS -t gpu ${modcc_opt}
-        TARGET build_all_gpu_mods
-    )
-endif()
+set(mech_dir "${CMAKE_CURRENT_SOURCE_DIR}/gpu")
+file(MAKE_DIRECTORY "${mech_dir}")
+build_modules(
+    ${mechanisms}
+    SOURCE_DIR "${mod_srcdir}"
+    DEST_DIR "${mech_dir}"
+    MODCC_FLAGS -t gpu ${modcc_opt}
+    TARGET build_all_gpu_mods
+)
 

--- a/modcc/cudaprinter.hpp
+++ b/modcc/cudaprinter.hpp
@@ -97,7 +97,7 @@ private:
         return module_->kind() == moduleKind::point;
     }
 
-    void print_APIMethod_body(APIMethod* e);
+    void print_APIMethod_body(ProcedureExpression* e);
     void print_procedure_prototype(ProcedureExpression *e);
     std::string index_string(Symbol *e);
 

--- a/src/memory/device_coordinator.hpp
+++ b/src/memory/device_coordinator.hpp
@@ -290,7 +290,9 @@ public:
 
     // fill memory
     void set(view_type &rng, value_type value) {
-        gpu::fill<value_type>(rng.data(), value, rng.size());
+        if (rng.size()) {
+            gpu::fill<value_type>(rng.data(), value, rng.size());
+        }
     }
 
     // generate reference objects for a raw pointer.


### PR DESCRIPTION
Fixes #183 

* Use a device kernel for `net_receive` state updates.

Note: very naive, but gives about a 30% speed up on the 1000 cell `miniapp` test. All the fun optimization will end up under issue #184.

This also incorporates PR #192, so this PR will be amended if that one is rejected.