### PR TITLE
More robust NMC_NUM_THREADS parsing

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ set(BASE_SOURCES
     parameter_list.cpp
     profiling/profiler.cpp
     swcio.cpp
+    threading/affinity.cpp
     util/debug.cpp
     util/path.cpp
     util/unwind.cpp

--- a/src/threading/affinity.cpp
+++ b/src/threading/affinity.cpp
@@ -1,0 +1,63 @@
+#include <vector>
+
+#include <cstdlib>
+
+#ifdef __linux__
+
+    #ifndef _GNU_SOURCE
+        #define _GNU_SOURCE
+    #endif
+
+    extern "C" {
+        #include <sched.h>
+    }
+
+#endif
+
+namespace nest {
+namespace mc {
+namespace threading {
+
+#ifdef __linux__
+std::vector<int> get_affinity() {
+    cpu_set_t cpu_set_mask;
+
+    auto status = sched_getaffinity(0, sizeof(cpu_set_t), &cpu_set_mask);
+
+    if(status==-1) {
+        return {};
+    }
+
+    auto cpu_count = CPU_COUNT(&cpu_set_mask);
+
+    std::vector<int> cores;
+    for(auto i=0; i<CPU_SETSIZE && cores.size()<cpu_count; ++i) {
+        if(CPU_ISSET(i, &cpu_set_mask)) {
+            cores.push_back(i);
+        }
+    }
+
+    if(cores.size() != cpu_count) {
+        return {};
+    }
+
+    return cores;
+}
+#else
+
+// No support for non-linux systems
+std::vector<int> get_affinity() {
+    return {};
+}
+#endif
+
+unsigned count_available_cores() {
+    auto n = get_affinity().size();
+
+    // Assume that there must be at least 1 core if an error was encountered.
+    return n? n: 1;
+}
+
+} // namespace threading
+} // namespace mc
+} // namespace nest

--- a/src/threading/affinity.cpp
+++ b/src/threading/affinity.cpp
@@ -52,10 +52,7 @@ std::vector<int> get_affinity() {
 #endif
 
 unsigned count_available_cores() {
-    auto n = get_affinity().size();
-
-    // Assume that there must be at least 1 core if an error was encountered.
-    return n? n: 1;
+    return get_affinity().size();
 }
 
 } // namespace threading

--- a/src/threading/affinity.hpp
+++ b/src/threading/affinity.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <vector>
+
+namespace nest {
+namespace mc {
+namespace threading {
+
+// The list of cores for which the calling thread has affinity.
+// If calling from the main thread at application start up, before
+// attempting to change thread affinity, may produce unreliable
+// results.
+//  - beware OpenMP thread pinning or custom job scheduler affinity
+//    flags that assign threads to specific cores.
+//
+// Returns an empty vector if unable to determine the number of
+// available cores.
+std::vector<int> get_affinity();
+
+// Attempts to find the number of cores available to the application
+// This is likely to give inaccurate results if the caller has already
+// been playing with thread affinity.
+unsigned count_available_cores();
+
+} // namespace threading
+} // namespace mc
+} // namespace nest

--- a/src/threading/affinity.hpp
+++ b/src/threading/affinity.hpp
@@ -20,6 +20,8 @@ std::vector<int> get_affinity();
 // Attempts to find the number of cores available to the application
 // This is likely to give inaccurate results if the caller has already
 // been playing with thread affinity.
+//
+// Returns 0 if unable to determine the number of cores.
 unsigned count_available_cores();
 
 } // namespace threading

--- a/src/threading/cthread.cpp
+++ b/src/threading/cthread.cpp
@@ -173,7 +173,7 @@ static size_t global_get_num_threads() {
         terminate("The requested number of threads \""+std::string(str)
             +"\" is not a positive integer");
     }
-    auto num_threads = std::stoi(str);
+
     return std::stoi(str);
 }
 

--- a/src/threading/cthread.cpp
+++ b/src/threading/cthread.cpp
@@ -168,13 +168,17 @@ static size_t global_get_num_threads() {
         return nthreads;
     }
 
+    auto nthreads = std::strtoul(str, nullptr, 10);
+
     // check that the environment variable string describes a non-negative integer
-    if (!std::regex_match(str, std::regex("\\s*\\d*[1-9]\\d*\\s*"))) {
+    if (nthreads==0 || errno==ERANGE ||
+        !std::regex_match(str, std::regex("\\s*\\d*[1-9]\\d*\\s*")))
+    {
         terminate("The requested number of threads \""+std::string(str)
-            +"\" is not a positive integer");
+            +"\" is not a reasonable positive integer");
     }
 
-    return std::stoi(str);
+    return nthreads;
 }
 
 task_pool& task_pool::get_global_task_pool() {


### PR DESCRIPTION
fixes #197

*  add functions that can find thread affinity and the number of available
   cores on linux systems via `sched_getaffinity`.
* on other systems they default to "unknown affinity" and return 0 to indicate
  that the number of cores is unknown.
*  set the default number of threads according to the new functions above
   if no environment variable explicitly setting the number of threads is set.
*  use std::stoi to convert string to unsigned to work around intel
   compiler bug, and potential bug if the user requests a negative
   number of threads.
* terminates if no number of threads is provided and the library
  is unable to determine a sensible number automatically.
* uses a simpler regex-based approach to validate the user-
  supplied NUM_NUM_THREADS string.