### PR TITLE
Tidy `event_queue` event class requirements.

### DIFF
--- a/src/event_queue.hpp
+++ b/src/event_queue.hpp
@@ -36,31 +36,18 @@ struct sample_event {
     time_type time;
 };
 
-namespace impl {
-    template <typename X>
-    struct has_time_field {
-        template <typename T>
-        static std::false_type test(...) {}
-        template <typename T>
-        static decltype(std::declval<T>().time, std::true_type{}) test(int) {}
-
-        using type = decltype(test<X>(0));
-        static constexpr bool value = type::value;
-    };
-}
-
 // Configuration point: define `event_time(ev)` for event objects `ev`
 // that do not have the corresponding `time` member field.
 
-template <typename Event, typename = util::enable_if_t<impl::has_time_field<Event>::value>>
+template <typename Event>
 auto event_time(const Event& ev) -> decltype(ev.time) {
     return ev.time;
 }
 
 namespace impl {
-    // use `impl::` version to obtain correct ADL for return type.
     using ::nest::mc::event_time;
 
+    // wrap in `impl::` namespace to obtain correct ADL for return type.
     template <typename Event>
     using event_time_type = decltype(event_time(std::declval<Event>()));
 }

--- a/tests/unit/test_event_queue.cpp
+++ b/tests/unit/test_event_queue.cpp
@@ -1,5 +1,6 @@
 #include "../gtest.h"
 
+#include <cmath>
 #include <vector>
 
 #include <event_queue.hpp>
@@ -16,38 +17,12 @@ TEST(event_queue, push)
     q.push({{8u, 2u}, 20.f, 2.f});
     q.push({{2u, 3u}, 8.f, 2.f});
 
-    std::vector<float> times;
-    while(q.size()) {
-        times.push_back(
-            q.pop_if_before(std::numeric_limits<float>::max())->time
-        );
-    }
-
-    //std::copy(times.begin(), times.end(), std::ostream_iterator<float>(std::cout, ","));
-    //std::cout << "\n";
-    EXPECT_TRUE(std::is_sorted(times.begin(), times.end()));
-}
-
-TEST(event_queue, push_range)
-{
-    using namespace nest::mc;
-    using ps_event_queue = event_queue<postsynaptic_spike_event<float>>;
-
-    postsynaptic_spike_event<float> events[] = {
-        {{1u, 0u}, 2.f, 2.f},
-        {{4u, 1u}, 1.f, 2.f},
-        {{8u, 2u}, 20.f, 2.f},
-        {{2u, 3u}, 8.f, 2.f}
-    };
-
-    ps_event_queue q;
-    q.push(std::begin(events), std::end(events));
+    EXPECT_EQ(4u, q.size());
 
     std::vector<float> times;
-    while(q.size()) {
-        times.push_back(
-            q.pop_if_before(std::numeric_limits<float>::max())->time
-        );
+    float maxtime(INFINITY);
+    while (!q.empty()) {
+        times.push_back(q.pop_if_before(maxtime)->time);
     }
 
     EXPECT_TRUE(std::is_sorted(times.begin(), times.end()));
@@ -73,37 +48,92 @@ TEST(event_queue, pop_if_before)
     };
 
     ps_event_queue q;
-    q.push(std::begin(events), std::end(events));
+    for (const auto& ev: events) {
+        q.push(ev);
+    }
 
-    EXPECT_EQ(q.size(), 4u);
+    EXPECT_EQ(4u, q.size());
 
     auto e1 = q.pop_if_before(0.);
     EXPECT_FALSE(e1);
-    EXPECT_EQ(q.size(), 4u);
+    EXPECT_EQ(4u, q.size());
 
     auto e2 = q.pop_if_before(5.);
     EXPECT_TRUE(e2);
     EXPECT_EQ(e2->target, target[0]);
-    EXPECT_EQ(q.size(), 3u);
+    EXPECT_EQ(3u, q.size());
 
     auto e3 = q.pop_if_before(5.);
     EXPECT_TRUE(e3);
     EXPECT_EQ(e3->target, target[1]);
-    EXPECT_EQ(q.size(), 2u);
+    EXPECT_EQ(2u, q.size());
 
     auto e4 = q.pop_if_before(2.5);
     EXPECT_FALSE(e4);
-    EXPECT_EQ(q.size(), 2u);
+    EXPECT_EQ(2u, q.size());
 
     auto e5 = q.pop_if_before(5.);
     EXPECT_TRUE(e5);
     EXPECT_EQ(e5->target, target[2]);
-    EXPECT_EQ(q.size(), 1u);
+    EXPECT_EQ(1u, q.size());
 
     q.pop_if_before(5.);
-    EXPECT_EQ(q.size(), 0u);
+    EXPECT_EQ(0u, q.size());
+    EXPECT_TRUE(q.empty());
 
     // empty queue should always return "false"
     auto e6 = q.pop_if_before(100.);
     EXPECT_FALSE(e6);
 }
+
+// Event queues can be defined for arbitrary copy-constructible events
+// for which `event_time(ev)` returns the corresponding time. Time values just
+// need to be well-ordered on '>'.
+
+struct wrapped_float {
+    wrapped_float() {}
+    wrapped_float(float f): f(f) {}
+
+    float f;
+    bool operator>(wrapped_float x) const { return f>x.f; }
+};
+
+struct minimal_event {
+    wrapped_float value;
+    explicit minimal_event(float x): value(x) {}
+};
+
+const wrapped_float& event_time(const minimal_event& ev) { return ev.value; }
+
+TEST(event_queue, minimal_event_impl)
+{
+    using nest::mc::event_queue;
+
+    minimal_event events[] = {
+        minimal_event(3.f),
+        minimal_event(2.f),
+        minimal_event(2.f),
+        minimal_event(10.f)
+    };
+
+    std::vector<float> expected;
+    for (const auto& ev: events) {
+        expected.push_back(ev.value.f);
+    }
+    std::sort(expected.begin(), expected.end());
+
+    event_queue<minimal_event> q;
+    for (auto& ev: events) {
+        q.push(ev);
+    }
+
+    wrapped_float maxtime(INFINITY);
+
+    std::vector<float> times;
+    while (q.size()) {
+        times.push_back(q.pop_if_before(maxtime)->value.f);
+    }
+
+    EXPECT_EQ(expected, times);
+}
+


### PR DESCRIPTION
The requirements for event types for use in `event_queue` were restrictive and a bit 'special'.

* Allow event times of any time which is well ordered by `operator>`.
* Allow any event type with a public `time` member containing the time value.
* Provide customization point `event_time()` via ADL for extracting the time value for event types that do not have a `time` member.
* Simplify interface: `push(begin, end)` was only ever used in the unit test; add `empty() const` method.
* Add unit test for more flexible functionality.