### PR TITLE
Implementation of asynchronous integration API.

### DIFF
--- a/miniapp/io.cpp
+++ b/miniapp/io.cpp
@@ -111,46 +111,13 @@ static void update_option(util::optional<T>& opt, const nlohmann::json& j, const
 
 // Read options from (optional) json file and command line arguments.
 cl_options read_options(int argc, char** argv, bool allow_write) {
-
-    // Default options:
-    const cl_options defopts{
-        1000,       // number of cells
-        500,        // synapses_per_cell
-        "expsyn",   // synapse type
-        100,        // compartments_per_segment
-        100.,       // tfinal
-        0.025,      // dt
-        false,      // all_to_all
-        false,      // ring
-        1,          // group_size
-        false,      // probe_soma_only
-        0.0,        // probe_ratio
-        "trace_",   // trace_prefix
-        util::nothing,  // trace_max_gid
-        util::nothing,  // morphologies
-        false,      // morph_rr;
-        false,      // report_compartments;
-
-        // spike_output_parameters:
-        false,      // spike output
-        false,      // single_file_per_simulation
-        true,       // Overwrite outputfile if exists
-        "./",       // output path
-        "spikes",   // file name
-        "gdf",      // file extension
-
-        // dry run parameters:
-        1,          // default dry run size
-
-        // Turn on/off profiling output for all ranks
-        false
-    };
-
     cl_options options;
     std::string save_file = "";
 
     // Parse command line arguments.
     try {
+        cl_options defopts;
+
         CustomCmdLine cmd("nest mc miniapp harness", "0.1");
 
         TCLAP::ValueArg<std::string> ifile_arg(
@@ -179,6 +146,11 @@ cl_options read_options(int argc, char** argv, bool allow_write) {
         TCLAP::ValueArg<double> dt_arg(
             "d", "dt", "set simulation time step to <time> ms",
             false, defopts.dt, "time", cmd);
+        TCLAP::ValueArg<double> bin_dt_arg(
+            "", "bin-dt", "set event binning interval to <time> ms",
+            false, defopts.bin_dt, "time", cmd);
+        TCLAP::SwitchArg bin_regular_arg(
+            "","bin-regular","use 'regular' binning policy instead of 'following'", cmd, false);
         TCLAP::SwitchArg all_to_all_arg(
             "m","alltoall","all to all network", cmd, false);
         TCLAP::SwitchArg ring_arg(
@@ -215,8 +187,6 @@ cl_options read_options(int argc, char** argv, bool allow_write) {
         cmd.reorder_arguments();
         cmd.parse(argc, argv);
 
-        options = defopts;
-
         std::string ifile_name = ifile_arg.getValue();
         if (ifile_name != "") {
             // Read parameters from specified JSON file first, to allow
@@ -232,6 +202,8 @@ cl_options read_options(int argc, char** argv, bool allow_write) {
                     update_option(options.syn_type, fopts, "syn_type");
                     update_option(options.compartments_per_segment, fopts, "compartments");
                     update_option(options.dt, fopts, "dt");
+                    update_option(options.bin_dt, fopts, "bin_dt");
+                    update_option(options.bin_regular, fopts, "bin_regular");
                     update_option(options.tfinal, fopts, "tfinal");
                     update_option(options.all_to_all, fopts, "all_to_all");
                     update_option(options.ring, fopts, "ring");
@@ -275,6 +247,8 @@ cl_options read_options(int argc, char** argv, bool allow_write) {
         update_option(options.compartments_per_segment, ncompartments_arg);
         update_option(options.tfinal, tfinal_arg);
         update_option(options.dt, dt_arg);
+        update_option(options.bin_dt, bin_dt_arg);
+        update_option(options.bin_regular, bin_regular_arg);
         update_option(options.all_to_all, all_to_all_arg);
         update_option(options.ring, ring_arg);
         update_option(options.group_size, group_size_arg);
@@ -315,6 +289,8 @@ cl_options read_options(int argc, char** argv, bool allow_write) {
                 fopts["syn_type"] = options.syn_type;
                 fopts["compartments"] = options.compartments_per_segment;
                 fopts["dt"] = options.dt;
+                fopts["bin_dt"] = options.bin_dt;
+                fopts["bin_regular"] = options.bin_regular;
                 fopts["tfinal"] = options.tfinal;
                 fopts["all_to_all"] = options.all_to_all;
                 fopts["ring"] = options.ring;
@@ -358,6 +334,9 @@ std::ostream& operator<<(std::ostream& o, const cl_options& options) {
     o << "  synapses/cell        : " << options.synapses_per_cell << "\n";
     o << "  simulation time      : " << options.tfinal << "\n";
     o << "  dt                   : " << options.dt << "\n";
+    o << "  binning dt           : " << options.bin_dt << "\n";
+    o << "  binning policy       : " <<
+        (options.bin_dt==0? "none": options.bin_regular? "regular": "following") << "\n";
     o << "  all to all network   : " << (options.all_to_all ? "yes" : "no") << "\n";
     o << "  ring network         : " << (options.ring ? "yes" : "no") << "\n";
     o << "  group size           : " << options.group_size << "\n";

--- a/miniapp/io.hpp
+++ b/miniapp/io.hpp
@@ -12,38 +12,51 @@ namespace nest {
 namespace mc {
 namespace io {
 
-// holds the options for a simulation run
+// Holds the options for a simulation run.
+// Default constructor gives default options.
+
 struct cl_options {
-    uint32_t cells;
-    uint32_t synapses_per_cell;
-    std::string syn_type;
-    uint32_t compartments_per_segment;
-    double tfinal;
-    double dt;
-    bool all_to_all;
-    bool ring;
-    uint32_t group_size;
-    bool probe_soma_only;
-    double probe_ratio;
-    std::string trace_prefix;
-    util::optional<unsigned> trace_max_gid;
+    // Cell parameters:
+    uint32_t cells = 1000;
+    uint32_t synapses_per_cell = 500;
+    std::string syn_type = "expsyn";
+    uint32_t compartments_per_segment = 100;
     util::optional<std::string> morphologies;
-    bool morph_rr;
-    bool report_compartments;
+    bool morph_rr = false; // False => pick morphologies randomly, true => pick morphologies round-robin.
 
-    // Parameters for spike output
-    bool spike_file_output;
-    bool single_file_per_rank;
-    bool over_write;
-    std::string output_path;
-    std::string file_name;
-    std::string file_extension;
+    // Network type (default is rgraph):
+    bool all_to_all = false;
+    bool ring = false;
 
-    // dry run parameters
-    int dry_run_ranks;
+    // Simulation running parameters:
+    double tfinal = 100.;
+    double dt = 0.025;
+    uint32_t group_size = 1;
+    bool bin_regular = false; // False => use 'following' instead of 'regular'.
+    double bin_dt = 0.0025;   // 0 => no binning.
 
-    // Turn on/off profiling output for all ranks
-    bool profile_only_zero;
+    // Probe/sampling specification.
+    bool probe_soma_only = false;
+    double probe_ratio = 0;  // Proportion of cells to probe.
+    std::string trace_prefix = "trace_";
+    util::optional<unsigned> trace_max_gid; // Only make traces up to this gid.
+
+    // Parameters for spike output.
+    bool spike_file_output = false;
+    bool single_file_per_rank = false;
+    bool over_write = true;
+    std::string output_path = "./";
+    std::string file_name = "spikes";
+    std::string file_extension = "gdf";
+
+    // Dry run parameters (pertinent only when built with 'dryrun' distrib model).
+    int dry_run_ranks = 1;
+
+    // Turn on/off profiling output for all ranks.
+    bool profile_only_zero = false;
+
+    // Report (inefficiently) on number of cell compartments in sim.
+    bool report_compartments = false;
 };
 
 class usage_error: public std::runtime_error {

--- a/miniapp/miniapp.cpp
+++ b/miniapp/miniapp.cpp
@@ -101,7 +101,15 @@ int main(int argc, char** argv) {
             report_compartment_stats(*recipe);
         }
 
-        // inject some artificial spikes, 1 per 20 neurons.
+        // Specify event binning/coalescing.
+        auto binning_policy =
+            options.bin_dt==0? binning_kind::none:
+            options.bin_regular? binning_kind::regular:
+            binning_kind::following;
+
+        m.set_binning_policy(binning_policy, options.bin_dt);
+
+        // Inject some artificial spikes, 1 per 20 neurons.
         std::vector<cell_gid_type> local_sources;
         cell_gid_type first_spike_cell = 20*((cell_range.first+19)/20);
         for (auto c=first_spike_cell; c<cell_range.second; c+=20) {
@@ -109,7 +117,7 @@ int main(int argc, char** argv) {
             m.add_artificial_spike({c, 0});
         }
 
-        // attach samplers to all probes
+        // Attach samplers to all probes
         std::vector<std::unique_ptr<sample_trace_type>> traces;
         const model_type::time_type sample_dt = 0.1;
         for (auto probe: m.probes()) {

--- a/src/cell_group.hpp
+++ b/src/cell_group.hpp
@@ -153,7 +153,7 @@ public:
             lowered_.add_event(binned_ev_time, handle, ev->weight);
         }
 
-        lowered_.start_integration(tfinal, dt);
+        lowered_.setup_integration(tfinal, dt);
 
         std::vector<sample_event<time_type>> requeue_sample_events;
         while (!lowered_.integration_complete()) {

--- a/src/cell_group.hpp
+++ b/src/cell_group.hpp
@@ -143,51 +143,61 @@ public:
     }
 
     void advance(time_type tfinal, time_type dt) {
-        while (lowered_.time()<tfinal) {
-            // take any pending samples
-            time_type cell_time = lowered_.time();
+        EXPECTS(lowered_.state_synchronized());
+
+        // Bin pending events and enqueue on lowered state.
+        time_type ev_min_time = lowered_.max_time(); // (but we're synchronized here)
+        while (auto ev = events_.pop_if_before(tfinal)) {
+            auto handle = get_target_handle(ev->target);
+            auto binned_ev_time = binner_.bin(ev->target.gid, ev->time, ev_min_time);
+            lowered_.add_event(binned_ev_time, handle, ev->weight);
+        }
+
+        lowered_.start_integration(tfinal, dt);
+
+        std::vector<sample_event<time_type>> requeue_sample_events;
+        while (!lowered_.integration_complete()) {
+            // Take any pending samples.
+            // TODO: Placeholder: this will be replaced by a backend polling implementation.
 
             PE("sampling");
-            while (auto m = sample_events_.pop_if_before(cell_time)) {
+            time_type cell_max_time = lowered_.max_time();
+
+            requeue_sample_events.clear();
+            while (auto m = sample_events_.pop_if_before(cell_max_time)) {
                 auto& s = samplers_[m->sampler_index];
                 EXPECTS((bool)s.sampler);
-                auto next = s.sampler(lowered_.time(), lowered_.probe(s.handle));
 
-                if (next) {
-                    m->time = std::max(*next, cell_time);
-                    sample_events_.push(*m);
+                time_type cell_time = lowered_.time(s.cell_gid-gid_base_);
+                if (cell_time<m->time) {
+                    // This cell hasn't reached this sample time yet.
+                    requeue_sample_events.push_back(*m);
                 }
+                else {
+                    auto next = s.sampler(cell_time, lowered_.probe(s.handle));
+                    if (next) {
+                        m->time = std::max(*next, cell_time);
+                        requeue_sample_events.push_back(*m);
+                    }
+                }
+            }
+            for (auto& ev: requeue_sample_events) {
+                sample_events_.push(std::move(ev));
             }
             PL();
 
-            // look for events in the next time step
-            time_type tstep = lowered_.time()+dt;
-            tstep = std::min(tstep, tfinal);
-            auto next = events_.pop_if_before(tstep);
+            // Ask lowered_ cell to integrate 'one step', delivering any
+            // events accordingly.
+            // TODO: Placeholder: with backend polling for samplers, we will
+            // request that the lowered cell perform the integration all the
+            // way to tfinal.
 
-            // apply events that are due within the smallest allowed time step.
-            while (next && (next->time-lowered_.time()) < 0.1*(dt)) {
-                auto handle = get_target_handle(next->target);
-                lowered_.deliver_event(handle, next->weight);
-                next = events_.pop_if_before(tstep);
-            }
-
-            // integrate cell state
-            time_type tnext = next ? next->time: tstep;
-            lowered_.advance(tnext - lowered_.time());
+            lowered_.step_integration();
 
             if (util::is_debug_mode() && !lowered_.is_physical_solution()) {
                 std::cerr << "warning: solution out of bounds for cell "
-                          << gid_base_ << " at t " << lowered_.time() << " ms\n";
+                          << gid_base_ << " at (max) t " << lowered_.max_time() << " ms\n";
             }
-
-            // apply events
-            PE("events");
-            if (next) {
-                auto handle = get_target_handle(next->target);
-                lowered_.deliver_event(handle, next->weight);
-            }
-            PL();
         }
 
         // Copy out spike voltage threshold crossings from the back end, then
@@ -206,7 +216,7 @@ public:
 
     template <typename R>
     void enqueue_events(const R& events) {
-        for (auto e : events) {
+        for (auto& e: events) {
             events_.push(e);
         }
     }
@@ -231,7 +241,7 @@ public:
         auto handle = get_probe_handle(probe_id);
 
         auto sampler_index = uint32_t(samplers_.size());
-        samplers_.push_back({handle, s});
+        samplers_.push_back({handle, probe_id.gid, s});
         sampler_start_times_.push_back(start_time);
         sample_events_.push({sampler_index, start_time});
     }
@@ -286,6 +296,7 @@ private:
 
     struct sampler_entry {
         typename lowered_cell_type::probe_handle handle;
+        cell_gid_type cell_gid;
         sampler_function sampler;
     };
 

--- a/src/fvm_multicell.hpp
+++ b/src/fvm_multicell.hpp
@@ -86,7 +86,7 @@ public:
     }
 
     /// Initialize state prior to a sequence of integration steps.
-    void start_integration(value_type tfinal, value_type dt_max) {
+    void setup_integration(value_type tfinal, value_type dt_max) {
         EXPECTS(tfinal>t_);
         EXPECTS(dt_max>0);
 
@@ -105,7 +105,7 @@ public:
         staged_events_.clear();
     }
 
-    /// Advance one integration step.
+    /// Advance one integration step, up to `dt_max_` in each cell.
     void step_integration();
 
     /// Query integration completion state.
@@ -834,6 +834,8 @@ void fvm_multicell<Backend>::reset() {
 
 template <typename Backend>
 void fvm_multicell<Backend>::step_integration() {
+    // Integrate cell states from `t_` by `dt_max_` if permissible,
+    // or otherwise until the next event time or `t_final`.
     EXPECTS(integration_running_);
 
     while (auto ev = events_.pop_if_not_after(t_)) {

--- a/src/model.hpp
+++ b/src/model.hpp
@@ -231,6 +231,13 @@ public:
         return bounds.second-bounds.first;
     }
 
+    // Set event binning policy on all our groups.
+    void set_binning_policy(binning_kind policy, time_type bin_interval) {
+        for (auto& group: cell_groups_) {
+            group.set_binning_policy(policy, bin_interval);
+        }
+    }
+
     // access cell_group directly
     cell_group_type& group(int i) {
         return cell_groups_[i];

--- a/tests/unit/test_cell_group.cpp
+++ b/tests/unit/test_cell_group.cpp
@@ -23,8 +23,7 @@ nest::mc::cell make_cell() {
 }
 
 TEST(cell_group, test) {
-    using cell_group_type = cell_group<fvm_cell>;
-    auto group = cell_group_type{0, util::singleton_view(make_cell())};
+    cell_group<fvm_cell> group{0, util::singleton_view(make_cell())};
 
     group.advance(50, 0.01);
 

--- a/tests/unit/test_event_queue.cpp
+++ b/tests/unit/test_event_queue.cpp
@@ -5,9 +5,9 @@
 
 #include <event_queue.hpp>
 
-TEST(event_queue, push)
-{
-    using namespace nest::mc;
+using namespace nest::mc;
+
+TEST(event_queue, push) {
     using ps_event_queue = event_queue<postsynaptic_spike_event<float>>;
 
     ps_event_queue q;
@@ -28,9 +28,7 @@ TEST(event_queue, push)
     EXPECT_TRUE(std::is_sorted(times.begin(), times.end()));
 }
 
-TEST(event_queue, pop_if_before)
-{
-    using namespace nest::mc;
+TEST(event_queue, pop_if_before) {
     using ps_event_queue = event_queue<postsynaptic_spike_event<float>>;
 
     cell_member_type target[4] = {
@@ -86,6 +84,34 @@ TEST(event_queue, pop_if_before)
     EXPECT_FALSE(e6);
 }
 
+TEST(event_queue, pop_if_not_after) {
+    struct event {
+        int time;
+
+        event(int t): time(t) {}
+    };
+
+    event_queue<event> queue;
+
+    queue.push(1);
+    queue.push(3);
+    queue.push(5);
+
+    auto e1 = queue.pop_if_not_after(2);
+    EXPECT_TRUE(e1);
+    EXPECT_EQ(1, e1->time);
+
+    auto e2 = queue.pop_if_before(3);
+    EXPECT_FALSE(e2);
+
+    auto e3 = queue.pop_if_not_after(3);
+    EXPECT_TRUE(e3);
+    EXPECT_EQ(3, e3->time);
+
+    auto e4 = queue.pop_if_not_after(4);
+    EXPECT_FALSE(e4);
+}
+
 // Event queues can be defined for arbitrary copy-constructible events
 // for which `event_time(ev)` returns the corresponding time. Time values just
 // need to be well-ordered on '>'.
@@ -105,10 +131,7 @@ struct minimal_event {
 
 const wrapped_float& event_time(const minimal_event& ev) { return ev.value; }
 
-TEST(event_queue, minimal_event_impl)
-{
-    using nest::mc::event_queue;
-
+TEST(event_queue, minimal_event_impl) {
     minimal_event events[] = {
         minimal_event(3.f),
         minimal_event(2.f),

--- a/tests/unit/test_fvm_multi.cpp
+++ b/tests/unit/test_fvm_multi.cpp
@@ -77,7 +77,9 @@ TEST(fvm_multi, init)
 
     // test that the matrix is initialized with sensible values
     //J.build_matrix(0.01);
-    fvcell.advance(0.01);
+    fvcell.start_integration(0.01, 0.01);
+    fvcell.step_integration();
+
     auto& mat = J.state_;
     auto test_nan = [](decltype(mat.u) v) {
         for(auto val : v) if(val != val) return false;

--- a/tests/unit/test_fvm_multi.cpp
+++ b/tests/unit/test_fvm_multi.cpp
@@ -77,7 +77,7 @@ TEST(fvm_multi, init)
 
     // test that the matrix is initialized with sensible values
     //J.build_matrix(0.01);
-    fvcell.start_integration(0.01, 0.01);
+    fvcell.setup_integration(0.01, 0.01);
     fvcell.step_integration();
 
     auto& mat = J.state_;

--- a/tests/unit/test_probe.cpp
+++ b/tests/unit/test_probe.cpp
@@ -73,7 +73,8 @@ TEST(probe, fvm_multicell)
     EXPECT_EQ(lcell.voltage()[probes[1].second], lcell.probe(probes[1]));
     EXPECT_EQ(lcell.current()[probes[2].second], lcell.probe(probes[2]));
 
-    lcell.advance(0.05);
+    lcell.start_integration(0.05, 0.05);
+    lcell.step_integration();
 
     EXPECT_EQ(lcell.voltage()[probes[0].second], lcell.probe(probes[0]));
     EXPECT_EQ(lcell.voltage()[probes[1].second], lcell.probe(probes[1]));

--- a/tests/unit/test_probe.cpp
+++ b/tests/unit/test_probe.cpp
@@ -73,7 +73,7 @@ TEST(probe, fvm_multicell)
     EXPECT_EQ(lcell.voltage()[probes[1].second], lcell.probe(probes[1]));
     EXPECT_EQ(lcell.current()[probes[2].second], lcell.probe(probes[2]));
 
-    lcell.start_integration(0.05, 0.05);
+    lcell.setup_integration(0.05, 0.05);
     lcell.step_integration();
 
     EXPECT_EQ(lcell.voltage()[probes[0].second], lcell.probe(probes[0]));


### PR DESCRIPTION
* Stage events for next integration interval on lowered cell.
* Use explicit binning for event coalescence.
* Extend `event_queue` to allow checking top of queue against arbitrary predicates.
* Add `--bin-dt` and `--bin-regular` options to miniapp (disable binning with `--bin-dt 0`).
* Tidy up miniapp option settings class.

Integration in lowered cell over multiple steps is deferred until samplers can be set up with back-end polling.

Asynchronous integration itself is not yet implemented.