### PR TITLE
change default threading model from serial to cthread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,8 @@ set(EXTERNAL_INCLUDES "")
 #----------------------------------------------------------
 # Threading model selection
 #----------------------------------------------------------
-set(NMC_THREADING_MODEL "serial" CACHE STRING "set the threading model, one of serial/tbb/cthread")
-set_property(CACHE NMC_THREADING_MODEL PROPERTY STRINGS serial tbb cthread)
+set(NMC_THREADING_MODEL "cthread" CACHE STRING "set the threading model, one of cthread/tbb/serial")
+set_property(CACHE NMC_THREADING_MODEL PROPERTY STRINGS cthread tbb serial )
 
 if(NMC_THREADING_MODEL MATCHES "tbb")
 


### PR DESCRIPTION
update the main `CMakeLists.txt` file to select the cthread back end by default, and present the threading options in the order: cthread, tbb, serial.

fixes #212