### PR TITLE
Implicit move ctor fix for the Intel compiler

### DIFF
--- a/src/util/indirect.hpp
+++ b/src/util/indirect.hpp
@@ -38,7 +38,9 @@ template <typename RASeq, typename Seq>
 auto indirect_view(RASeq& data, const Seq& index_map)
 DEDUCED_RETURN_TYPE(transform_view(index_map, impl::indirect_accessor<RASeq&>(data)));
 
-template <typename RASeq, typename Seq>
+// icpc 17 fails to disambiguate without further qualification, so
+// we replace `template <typename RASeq, typename Seq>` with the following:
+template <typename RASeq, typename Seq, typename = util::enable_if_t<!std::is_reference<RASeq>::value>>
 auto indirect_view(RASeq&& data, const Seq& index_map)
 DEDUCED_RETURN_TYPE(transform_view(index_map, impl::indirect_accessor<RASeq>(std::move(data))));
 

--- a/src/util/iterutil.hpp
+++ b/src/util/iterutil.hpp
@@ -89,8 +89,8 @@ auto back(Seq& seq) -> decltype(*std::begin(seq)) {
  */
 template <typename V>
 struct pointer_proxy: public V {
-    pointer_proxy(const V& v): V{v} {}
-    pointer_proxy(V&& v): V{std::move(v)} {}
+    pointer_proxy(const V& v): V(v) {}
+    pointer_proxy(V&& v): V(std::move(v)) {}
     const V* operator->() const { return this; }
 };
 

--- a/tests/unit/test_transform.cpp
+++ b/tests/unit/test_transform.cpp
@@ -79,7 +79,6 @@ TEST(transform, pointer_access) {
 TEST(transform, pointer_proxy) {
     struct item {
         int x;
-        item(int&& v) { x = v; }
     };
     auto r = util::transform_view(util::make_span(0, 3), [&](int i) { return item{13+i}; });
 

--- a/tests/unit/test_transform.cpp
+++ b/tests/unit/test_transform.cpp
@@ -79,6 +79,7 @@ TEST(transform, pointer_access) {
 TEST(transform, pointer_proxy) {
     struct item {
         int x;
+        item(int&& v) { x = v; }
     };
     auto r = util::transform_view(util::make_span(0, 3), [&](int i) { return item{13+i}; });
 


### PR DESCRIPTION
Intel compiler (at least v16) seems not to generate an implicit move constructor.