### PR TITLE
Initial microbenchmark builds.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/ubench/google-benchmark"]
+	path = tests/ubench/google-benchmark
+	url = https://github.com/google/benchmark

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,10 @@ add_subdirectory(global_communication)
 # Tests for performance: This could include stand alone tests. These do not necessarily be run automatically
 add_subdirectory(performance)
 
+# Microbenchmarks.
+add_subdirectory(ubench)
+
+
 # modcc tests
 if(NOT use_external_modcc)
     add_subdirectory(modcc)

--- a/tests/ubench/CMakeLists.txt
+++ b/tests/ubench/CMakeLists.txt
@@ -1,23 +1,40 @@
 include(ExternalProject)
 
-set(gbench_install_dir "${PROJECT_BINARY_DIR}/gbench")
-
-set(gbench_cmake_args
-    -DCMAKE_BUILD_TYPE=release
-    -DCMAKE_INSTALL_PREFIX=${gbench_install_dir}
-    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER})
-
-ExternalProject_Add(gbench
-    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/google-benchmark"
-    CMAKE_ARGS "${gbench_cmake_args}"
-#    INSTALL_DIR "${gbench_install_dir}"
-)
-
-message(STATUS "gbench_install_dir:  ${gbench_install_dir}")
+# List of micro benchmarks to build.
 
 set(bench_sources
     accumulate_functor_values.cpp)
+
+# Set up google benchmark as an external project.
+
+set(gbench_src_dir "${CMAKE_CURRENT_SOURCE_DIR}/google-benchmark")
+set(gbench_install_dir "${PROJECT_BINARY_DIR}/gbench")
+
+set(gbench_cmake_args
+    "-DCMAKE_BUILD_TYPE=release"
+    "-DCMAKE_INSTALL_PREFIX=${gbench_install_dir}"
+    "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
+    "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
+
+
+# Attempt to update git submodule if required.
+find_package(Git)
+if(NOT EXISTS "${gbench_src_dir}/.git")
+    if(GIT_FOUND)
+        exec_program("${GIT_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}"
+            ARGS submodule update --init google-benchmark)
+    else()
+        message(WARNING "google-benchmark submodule apparently not updated, but cannot find git")
+    endif()
+endif()
+
+ExternalProject_Add(gbench
+    SOURCE_DIR "${gbench_src_dir}"
+    CMAKE_ARGS "${gbench_cmake_args}"
+    INSTALL_DIR "${gbench_install_dir}"
+)
+
+# Build benches.
 
 foreach(bench_src ${bench_sources})
     string(REGEX REPLACE "\\.[^.]*$" "" bench_exe "${bench_src}")

--- a/tests/ubench/CMakeLists.txt
+++ b/tests/ubench/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NOT EXISTS "${gbench_src_dir}/.git")
         exec_program("${GIT_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}"
             ARGS submodule update --init google-benchmark)
     else()
-        message(WARNING "google-benchmark submodule apparently not updated, but cannot find git")
+        message(WARNING "Unable to update the google-benchmark submodule: git not found.")
     endif()
 endif()
 
@@ -33,12 +33,13 @@ ExternalProject_Add(gbench
     CMAKE_ARGS "${gbench_cmake_args}"
     INSTALL_DIR "${gbench_install_dir}"
 )
+set_target_properties(gbench PROPERTIES EXCLUDE_FROM_ALL TRUE)
 
 # Build benches.
 
 foreach(bench_src ${bench_sources})
     string(REGEX REPLACE "\\.[^.]*$" "" bench_exe "${bench_src}")
-    add_executable("${bench_exe}" "${bench_src}")
+    add_executable("${bench_exe}" EXCLUDE_FROM_ALL "${bench_src}")
     add_dependencies("${bench_exe}" gbench)
     target_include_directories("${bench_exe}" PRIVATE "${gbench_install_dir}/include")
     target_link_libraries("${bench_exe}" "${gbench_install_dir}/lib/libbenchmark.a")

--- a/tests/ubench/CMakeLists.txt
+++ b/tests/ubench/CMakeLists.txt
@@ -1,0 +1,33 @@
+include(ExternalProject)
+
+set(gbench_install_dir "${PROJECT_BINARY_DIR}/gbench")
+
+set(gbench_cmake_args
+    -DCMAKE_BUILD_TYPE=release
+    -DCMAKE_INSTALL_PREFIX=${gbench_install_dir}
+    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER})
+
+ExternalProject_Add(gbench
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/google-benchmark"
+    CMAKE_ARGS "${gbench_cmake_args}"
+#    INSTALL_DIR "${gbench_install_dir}"
+)
+
+message(STATUS "gbench_install_dir:  ${gbench_install_dir}")
+
+set(bench_sources
+    accumulate_functor_values.cpp)
+
+foreach(bench_src ${bench_sources})
+    string(REGEX REPLACE "\\.[^.]*$" "" bench_exe "${bench_src}")
+    add_executable("${bench_exe}" "${bench_src}")
+    add_dependencies("${bench_exe}" gbench)
+    target_include_directories("${bench_exe}" PRIVATE "${gbench_install_dir}/include")
+    target_link_libraries("${bench_exe}" "${gbench_install_dir}/lib/libbenchmark.a")
+
+    list(APPEND bench_exe_list ${bench_exe})
+endforeach()
+
+add_custom_target(ubenches DEPENDS ${bench_exe_list})
+

--- a/tests/ubench/README.md
+++ b/tests/ubench/README.md
@@ -37,8 +37,8 @@ become otherwise unwieldy.
 #### Motivation
 
 The problem arises when constructing the partition of an integral range where the sizes of each
-sub-interval are given by a function of the index. This requires the computation of
-> d<sub><i>i</i></sub> = Σ<sub><i>j</i>&lt;<i>i</i> <i>f</i>(<i>j</i>).
+sub-interval are given by a function of the index. This requires the computation of the sizes
+> d<sub><i>i</i></sub> = Σ<sub><i>j</i>&lt;<i>i</i></sub> <i>f</i>(<i>j</i>).
 
 One approach using the provided range utilities is to use `std::partial_sum` with
 `util::transform_view` and `util::span`; the other is to simply write a loop that
@@ -55,12 +55,11 @@ Results here are presented only for vector size _n_ equal to 1024.
 Platform:
 *  Xeon E3-1220 v2 with base clock 3.1 GHz and max clock 3.5 GHz. 
 *  Linux 4.4.34
-*  gcc version 6.2.0 and clang version 3.8.1
+*  gcc version 6.2.0
+*  clang version 3.8.1
 
 | Compiler    | direct/function | transform/function | direct/object | transform/object |
-|-------------|-----------------|--------------------|---------------|------------------|
-| g++ -O3     | 907 ns | 2090 ns | 907 ns | 614 ns |
-| clang++ -O3 | 1063 ns | 533 ns | 1051 ns | 532 ns |
-
-
+|:------------|----------------:|-------------------:|--------------:|-----------------:|
+| g++ -O3     |  907 ns | 2090 ns |  907 ns | 614 ns |
+| clang++ -O3 | 1063 ns |  533 ns | 1051 ns | 532 ns |
 

--- a/tests/ubench/README.md
+++ b/tests/ubench/README.md
@@ -1,0 +1,66 @@
+# Library microbenchmarks
+
+The benchmarks here are intended to:
+* answer questions regarding choices of implementation in the library where performance is a concern;
+* track the performance behaviour of isolated bits of library functionality across different platforms.
+
+
+## Building and running
+
+The micro-benchmarks are not built by default. After configuring CMake, they can be built with
+`make ubenches`. Each benchmark is provided by a stand-alone C++ source file in `tests/ubench`;
+the resulting executables are found in `test/ubench` relative to the build directory.
+
+[Google benchmark](https://github.com/google/benchmark) is used as a harness. It is included
+in the repository via a git submodule, and the provided CMake scripts will attempt to
+run `git submodule update --init` on the submodule if it appears not to have been instantiated.
+
+
+## Adding new benchmarks
+
+New benchmarks are added by placing the corresponding implementation as a stand-alone
+`.cpp` file in `tests/ubench` and adding the name of this file to the list `bench_sources`
+in `tests/ubench/CMakeLists.txt`.
+
+Each new benchmark should also have a corresponding entry in this `README.md`, describing
+the motivation for the test and summarising at least one benchmark result.
+
+Results in this file are destined to become out of date; we should consider some form
+of semi-automated registration of results in a database should the number of benchmarks
+become otherwise unwieldy.
+
+
+## Benchmarks
+
+### `accumulate_functor_values`
+
+#### Motivation
+
+The problem arises when constructing the partition of an integral range where the sizes of each
+sub-interval are given by a function of the index. This requires the computation of
+> d<sub><i>i</i></sub> = Σ<sub><i>j</i>&lt;<i>i</i> <i>f</i>(<i>j</i>).
+
+One approach using the provided range utilities is to use `std::partial_sum` with
+`util::transform_view` and `util::span`; the other is to simply write a loop that
+performs the accumulation directly. What is the extra cost, if any, of the
+transform-based approach?
+
+The micro-benchmark compares the two implementations, where the function is a simple
+integer square operation, called either via a function pointer or a functional object.
+
+#### Results
+
+Results here are presented only for vector size _n_ equal to 1024.
+
+Platform:
+*  Xeon E3-1220 v2 with base clock 3.1 GHz and max clock 3.5 GHz. 
+*  Linux 4.4.34
+*  gcc version 6.2.0 and clang version 3.8.1
+
+| Compiler    | direct/function | transform/function | direct/object | transform/object |
+|-------------|-----------------|--------------------|---------------|------------------|
+| g++ -O3     | 907 ns | 2090 ns | 907 ns | 614 ns |
+| clang++ -O3 | 1063 ns | 533 ns | 1051 ns | 532 ns |
+
+
+

--- a/tests/ubench/accumulate_functor_values.cpp
+++ b/tests/ubench/accumulate_functor_values.cpp
@@ -1,0 +1,67 @@
+#undef NDEBUG
+
+#include <cassert>
+#include <numeric>
+#include <vector>
+
+#include <benchmark/benchmark.h>
+
+#include <util/span.hpp>
+#include <util/transform.hpp>
+
+
+using namespace nest::mc;
+
+inline long long square(long long x) { return x*x; }
+
+long long sum_squares_to(long long x) {
+    return x<1? 0: (2*x*x*x+3*x*x+x)/6;
+}
+
+template <typename Func>
+void partial_sums_direct(Func f, int upto, std::vector<long long>& psum) {
+    long long sum = 0;
+    for (int i=1; i<=upto; ++i) {
+        sum += f(i);
+        psum[i-1] = sum;
+    }
+}
+
+template <typename Func>
+void partial_sums_transform(Func f, int upto, std::vector<long long>& psum) {
+    auto nums = util::span<long long>(1, upto+1);
+    auto values = util::transform_view(nums, f);
+    std::partial_sum(values.begin(), values.end(), psum.begin());
+}
+
+void bench_accum_direct(benchmark::State& state) {
+    int upto = state.range(0);
+    std::vector<long long> psum(upto);
+
+    while (state.KeepRunning()) {
+        partial_sums_direct(square, upto, psum);
+    }
+
+    for (int i = 0; i<upto; ++i) {
+        assert(sum_squares_to(i+1)==psum[i]);
+    }
+}
+
+void bench_accum_transform(benchmark::State& state) {
+    int upto = state.range(0);
+    std::vector<long long> psum(upto);
+
+    while (state.KeepRunning()) {
+        partial_sums_transform(square, upto, psum);
+    }
+
+    for (int i = 0; i<upto; ++i) {
+        assert(sum_squares_to(i+1)==psum[i]);
+    }
+}
+
+
+BENCHMARK(bench_accum_direct)->RangeMultiplier(2)->Range(2, 1<<10);
+BENCHMARK(bench_accum_transform)->RangeMultiplier(2)->Range(2, 1<<10);
+BENCHMARK_MAIN();
+


### PR DESCRIPTION
* Use git submodule for incorporating Google benchmark library.
* Add one microbenchmark for comparing `util::transform_view` performance.

Note that the microbenchmarks are not built by default; they can be built with `make ubenches`, and then run individually. The microbenchmarks will be built in `tests/ubench/`, relative to the build directory.