### PR TITLE
Move string-printf utility from lmorpho into util.

### DIFF
--- a/lmorpho/morphio.cpp
+++ b/lmorpho/morphio.cpp
@@ -6,31 +6,14 @@
 
 #include <morphology.hpp>
 #include <swcio.hpp>
+#include <util/strprintf.hpp>
 
 #include "morphio.hpp"
 
 using nest::mc::io::swc_record;
+using nest::mc::util::strprintf;
 
 std::vector<swc_record> as_swc(const nest::mc::morphology& morph);
-
-// printf wrappers.
-
-template <typename... Args>
-static std::string strprintf(const char* fmt, Args&&... args) {
-    thread_local static std::vector<char> buffer(1024);
-
-    for (;;) {
-        int n = std::snprintf(buffer.data(), buffer.size(), fmt, std::forward<Args>(args)...);
-        if (n<0) return ""; // error
-        if ((unsigned)n<buffer.size()) return std::string(buffer.data());
-        buffer.resize(2*n);
-    }
-}
-
-template <typename... Args>
-static std::string strprintf(std::string fmt, Args&&... args) {
-    return strprintf(fmt.c_str(), std::forward<Args>(args)...);
-}
 
 // Multi-file manager implementation.
 multi_file::multi_file(const std::string& pattern, int digits) {

--- a/src/util/strprintf.hpp
+++ b/src/util/strprintf.hpp
@@ -27,7 +27,7 @@ namespace impl {
 }
 
 template <typename... Args>
-static std::string strprintf(const char* fmt, Args&&... args) {
+std::string strprintf(const char* fmt, Args&&... args) {
     thread_local static std::vector<char> buffer(1024);
 
     for (;;) {
@@ -36,14 +36,14 @@ static std::string strprintf(const char* fmt, Args&&... args) {
             throw std::system_error(errno, std::generic_category());
         }
         else if ((unsigned)n<buffer.size()) {
-            return std::string(buffer.data());
+            return std::string(buffer.data(), n);
         }
         buffer.resize(2*n);
     }
 }
 
 template <typename... Args>
-static std::string strprintf(std::string fmt, Args&&... args) {
+std::string strprintf(const std::string& fmt, Args&&... args) {
     return strprintf(fmt.c_str(), std::forward<Args>(args)...);
 }
 

--- a/src/util/strprintf.hpp
+++ b/src/util/strprintf.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+/* Thin wrapper around std::snprintf for sprintf-like formatting
+ * to std::string. */
+
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace nest {
+namespace mc {
+namespace util {
+
+namespace impl {
+    template <typename X>
+    X sprintf_arg_translate(const X& x) { return x; }
+
+    inline const char* sprintf_arg_translate(const std::string& x) { return x.c_str(); }
+
+    template <typename T, typename Deleter>
+    T* sprintf_arg_translate(const std::unique_ptr<T, Deleter>& x) { return x.get(); }
+
+    template <typename T>
+    T* sprintf_arg_translate(const std::shared_ptr<T>& x) { return x.get(); }
+}
+
+template <typename... Args>
+static std::string strprintf(const char* fmt, Args&&... args) {
+    thread_local static std::vector<char> buffer(1024);
+
+    for (;;) {
+        int n = std::snprintf(buffer.data(), buffer.size(), fmt, impl::sprintf_arg_translate(std::forward<Args>(args))...);
+        if (n<0) {
+            throw std::system_error(errno, std::generic_category());
+        }
+        else if ((unsigned)n<buffer.size()) {
+            return std::string(buffer.data());
+        }
+        buffer.resize(2*n);
+    }
+}
+
+template <typename... Args>
+static std::string strprintf(std::string fmt, Args&&... args) {
+    return strprintf(fmt.c_str(), std::forward<Args>(args)...);
+}
+
+} // namespace util
+} // namespace mc
+} // namespace nest

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -59,6 +59,7 @@ set(TEST_SOURCES
     test_spikes.cpp
     test_spike_store.cpp
     test_stimulus.cpp
+    test_strprintf.cpp
     test_swcio.cpp
     test_synapses.cpp
     test_tree.cpp

--- a/tests/unit/test_strprintf.cpp
+++ b/tests/unit/test_strprintf.cpp
@@ -1,0 +1,63 @@
+#include <cstdio>
+#include <memory>
+#include <string>
+
+#include "../gtest.h"
+#include <util/strprintf.hpp>
+
+using namespace nest::mc::util;
+
+
+TEST(strprintf, simple) {
+    char buf[200];
+
+    const char* fmt1 = " %% %04d % 3.2f %#016x %c";
+    sprintf(buf, fmt1, 3, 7.1e-3, 0x1234ul, 'x');
+    auto result = strprintf(fmt1, 3, 7.1e-3, 0x1234ul, 'x');
+    EXPECT_EQ(std::string(buf), result);
+
+    const char* fmt2 = "%5s %3s";
+    sprintf(buf, fmt2, "bear", "pear");
+    result = strprintf(fmt2, "bear", "pear");
+    EXPECT_EQ(std::string(buf), result);
+}
+
+TEST(strprintf, longstr) {
+    std::string aaaa(2000, 'a');
+    std::string bbbb(2000, 'b');
+    std::string x;
+
+    x = aaaa;
+    ASSERT_EQ(x, strprintf("%s", x.c_str()));
+
+    x += bbbb+x;
+    ASSERT_EQ(x, strprintf("%s", x.c_str()));
+
+    x += bbbb+x;
+    ASSERT_EQ(x, strprintf("%s", x.c_str()));
+
+    x += bbbb+x;
+    ASSERT_EQ(x, strprintf("%s", x.c_str()));
+
+    x += bbbb+x;
+    ASSERT_EQ(x, strprintf("%s", x.c_str()));
+}
+
+TEST(strprintf, wrappers) {
+    // can we print strings and smart-pointers directly?
+
+    char buf[200];
+
+    auto uptr = std::unique_ptr<int>{new int(17)};
+    sprintf(buf, "uptr %p", uptr.get());
+
+    EXPECT_EQ(std::string(buf), strprintf("uptr %p", uptr));
+
+    auto sptr = std::shared_ptr<double>{new double(19.)};
+    sprintf(buf, "sptr %p", sptr.get());
+
+    EXPECT_EQ(std::string(buf), strprintf("sptr %p", sptr));
+
+    EXPECT_EQ(std::string("fish"), strprintf("fi%s", std::string("sh")));
+}
+


### PR DESCRIPTION
* Add `util::strprintf` printf-alike function that returns a `std::string` result.
* Include simple adaptors for `std::string` and standard smart pointer arguments fot `util::strprintf` (i.e. `std::string` arguments can be used with `%s`, smart pointers with `%p`).
* Add unit tests to suit.