### PR TITLE
modularize domain decomposition

### DIFF
--- a/miniapp/miniapp.cpp
+++ b/miniapp/miniapp.cpp
@@ -84,10 +84,12 @@ int main(int argc, char** argv) {
                     options.file_extension, options.over_write);
         };
 
-        auto backend = config::has_cuda?
+        group_rules rules;
+        rules.policy = config::has_cuda?
             backend_policy::prefer_gpu: backend_policy::use_multicore;
+        rules.target_group_size = options.group_size;
 
-        model m(*recipe, backend);
+        model m(*recipe, rules);
 
         if (options.report_compartments) {
             report_compartment_stats(*recipe);
@@ -102,8 +104,7 @@ int main(int argc, char** argv) {
         m.set_binning_policy(binning_policy, options.bin_dt);
 
         // Inject some artificial spikes, 1 per 20 neurons.
-        cell_gid_type first_spike_cell = 20*((cell_range.first+19)/20);
-        for (auto c=first_spike_cell; c<cell_range.second; c+=20) {
+        for (cell_gid_type c=0; c<recipe->num_cells(); c+=20) {
             m.add_artificial_spike({c, 0});
         }
 

--- a/miniapp/miniapp.cpp
+++ b/miniapp/miniapp.cpp
@@ -88,8 +88,9 @@ int main(int argc, char** argv) {
         rules.policy = config::has_cuda?
             backend_policy::prefer_gpu: backend_policy::use_multicore;
         rules.target_group_size = options.group_size;
+        auto decomp = domain_decomposition(*recipe, rules);
 
-        model m(*recipe, rules);
+        model m(*recipe, decomp);
 
         if (options.report_compartments) {
             report_compartment_stats(*recipe);

--- a/src/domain_decomposition.hpp
+++ b/src/domain_decomposition.hpp
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#include <backends.hpp>
 #include <common_types.hpp>
 #include <communication/global_policy.hpp>
 #include <recipe.hpp>
@@ -12,8 +13,12 @@
 namespace nest {
 namespace mc {
 
-//TODO: interface for global gid_partition
-//required by the communicator for one
+// Meta data used to guide the domain_decomposition in distributing
+// and grouping cells.
+struct group_rules {
+    cell_gid_type target_group_size;
+    backend_policy policy;
+};
 
 class domain_decomposition {
 public:
@@ -25,37 +30,35 @@ public:
         cell_kind kind;
     };
 
-    domain_decomposition(const recipe& rec, gid_type target_group_size) {
-        EXPECTS(target_group_size>0);
+    domain_decomposition(const recipe& rec, const group_rules& rules) {
+        EXPECTS(rules.target_group_size>0);
 
         auto num_domains = communication::global_policy::size();
         auto domain_id = communication::global_policy::id();
 
-        // partition the cells across the domain
+        // partition the cells globally across the domains
         num_global_cells_ = rec.num_cells();
         first_cell_ = (gid_type)(num_global_cells_*(domain_id/(double)num_domains));
         last_cell_ = (gid_type)(num_global_cells_*((domain_id+1)/(double)num_domains));
 
+        // partition the local cells into cell groups
         if (num_local_cells()>0) {
             gid_type group_size = 1;
-            gid_type group_first = first_cell_;
-            auto group_kind = rec.get_cell_kind(group_first);
-            gid_type gid = group_first+1;
+            group_starts_.push_back(first_cell_);
+            auto group_kind = rec.get_cell_kind(first_cell_);
+            group_kinds_.push_back(group_kind);
+            gid_type gid = first_cell_+1;
             while (gid<last_cell_) {
                 auto kind = rec.get_cell_kind(gid);
-                if (kind!=group_kind || group_size>=target_group_size) {
-                    groups_.push_back({group_first, gid, group_kind});
-                    group_kind = kind;
-                    group_first = gid;
+                if (kind!=group_kind || group_size>=rules.target_group_size) {
+                    group_starts_.push_back(gid);
+                    group_kinds_.push_back(kind);
                     group_size = 0;
                 }
                 ++group_size;
                 ++gid;
             }
-            groups_.push_back({group_first, gid, group_kind});
-
-            EXPECTS(groups_.front().from==first_cell_);
-            EXPECTS(groups_.back().to==last_cell_);
+            group_starts_.push_back(last_cell_);
         }
     }
 
@@ -64,7 +67,7 @@ public:
         if (!is_local_gid(i)) {
             return util::nothing;
         }
-        // TODO: finish binary search
+        return local_gid_partition().index(i);
     }
 
     gid_type first_cell() const {
@@ -85,31 +88,28 @@ public:
     }
 
     gid_type num_local_groups() const {
-        return groups_.size();
+        return group_kinds_.size();
     }
 
     group_range_type get_group(gid_type i) const {
-        return groups_[i];
+        return {group_starts_[i], group_starts_[i+1], group_kinds_[i]};
     }
 
     bool is_local_gid(gid_type i) const {
         return i>=first_cell_ && i<last_cell_;
     }
 
-    /*
-    auto cell_partition() const {
-        auto x =
-            util::partition_view(
-                util::transform_view(groups_, [](group_range_type g){return g.from;}));
+    auto local_gid_partition() -> decltype(util::partition_view(std::vector<gid_type>())) const {
+        return util::partition_view(group_starts_);
     }
-    */
 
 private:
 
     gid_type first_cell_;
     gid_type last_cell_;
     gid_type num_global_cells_;
-    std::vector<group_range_type> groups_;
+    std::vector<gid_type> group_starts_;
+    std::vector<cell_kind> group_kinds_;
 };
 
 } // namespace mc

--- a/src/domain_decomposition.hpp
+++ b/src/domain_decomposition.hpp
@@ -135,6 +135,10 @@ public:
         return util::partition_view(group_starts_);
     }
 
+    backend_policy backend() const {
+        return backend_policy_;
+    }
+
 private:
 
     backend_policy backend_policy_;

--- a/src/domain_decomposition.hpp
+++ b/src/domain_decomposition.hpp
@@ -131,10 +131,12 @@ public:
         return i>=cell_begin_ && i<cell_end_;
     }
 
+    /// Return a partition of the cell gid over local cell groups.
     gid_partition_type gid_group_partition() const {
         return util::partition_view(group_starts_);
     }
 
+    /// Returns the backend policy.
     backend_policy backend() const {
         return backend_policy_;
     }

--- a/src/domain_decomposition.hpp
+++ b/src/domain_decomposition.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <vector>
+
+#include <common_types.hpp>
+#include <communication/global_policy.hpp>
+#include <recipe.hpp>
+#include <util/optional.hpp>
+#include <util/partition.hpp>
+#include <util/transform.hpp>
+
+namespace nest {
+namespace mc {
+
+//TODO: interface for global gid_partition
+//required by the communicator for one
+
+class domain_decomposition {
+public:
+    using gid_type = cell_gid_type;
+
+    struct group_range_type {
+        gid_type from;
+        gid_type to;
+        cell_kind kind;
+    };
+
+    domain_decomposition(const recipe& rec, gid_type target_group_size) {
+        EXPECTS(target_group_size>0);
+
+        auto num_domains = communication::global_policy::size();
+        auto domain_id = communication::global_policy::id();
+
+        // partition the cells across the domain
+        num_global_cells_ = rec.num_cells();
+        first_cell_ = (gid_type)(num_global_cells_*(domain_id/(double)num_domains));
+        last_cell_ = (gid_type)(num_global_cells_*((domain_id+1)/(double)num_domains));
+
+        if (num_local_cells()>0) {
+            gid_type group_size = 1;
+            gid_type group_first = first_cell_;
+            auto group_kind = rec.get_cell_kind(group_first);
+            gid_type gid = group_first+1;
+            while (gid<last_cell_) {
+                auto kind = rec.get_cell_kind(gid);
+                if (kind!=group_kind || group_size>=target_group_size) {
+                    groups_.push_back({group_first, gid, group_kind});
+                    group_kind = kind;
+                    group_first = gid;
+                    group_size = 0;
+                }
+                ++group_size;
+                ++gid;
+            }
+            groups_.push_back({group_first, gid, group_kind});
+
+            EXPECTS(groups_.front().from==first_cell_);
+            EXPECTS(groups_.back().to==last_cell_);
+        }
+    }
+
+    util::optional<gid_type> local_group_from_gid(gid_type i) {
+        // check if gid is a local cell
+        if (!is_local_gid(i)) {
+            return util::nothing;
+        }
+        // TODO: finish binary search
+    }
+
+    gid_type first_cell() const {
+        return first_cell_;
+    }
+
+    gid_type last_cell() const {
+        return last_cell_;
+    }
+
+    gid_type num_global_cells() const {
+        return last_cell_;
+    }
+
+    gid_type num_local_cells() const {
+        // valid when the invariant last_cell >= first_cell is satisfied
+        return last_cell()-first_cell();
+    }
+
+    gid_type num_local_groups() const {
+        return groups_.size();
+    }
+
+    group_range_type get_group(gid_type i) const {
+        return groups_[i];
+    }
+
+    bool is_local_gid(gid_type i) const {
+        return i>=first_cell_ && i<last_cell_;
+    }
+
+    /*
+    auto cell_partition() const {
+        auto x =
+            util::partition_view(
+                util::transform_view(groups_, [](group_range_type g){return g.from;}));
+    }
+    */
+
+private:
+
+    gid_type first_cell_;
+    gid_type last_cell_;
+    gid_type num_global_cells_;
+    std::vector<group_range_type> groups_;
+};
+
+} // namespace mc
+} // namespace nest

--- a/src/domain_decomposition.hpp
+++ b/src/domain_decomposition.hpp
@@ -16,38 +16,61 @@ namespace mc {
 // Meta data used to guide the domain_decomposition in distributing
 // and grouping cells.
 struct group_rules {
-    cell_gid_type target_group_size;
+    cell_size_type target_group_size;
     backend_policy policy;
 };
 
 class domain_decomposition {
+    using gid_partition_type =
+        util::partition_range<std::vector<cell_gid_type>::const_iterator>;
+
 public:
+    /// Utility type for meta data for a local cell group.
     struct group_range_type {
-        cell_gid_type from;
-        cell_gid_type to;
+        cell_gid_type begin;
+        cell_gid_type end;
         cell_kind kind;
     };
 
-    domain_decomposition(const recipe& rec, const group_rules& rules) {
+    domain_decomposition(const recipe& rec, const group_rules& rules):
+        backend_policy_(rules.policy)
+    {
         EXPECTS(rules.target_group_size>0);
 
         auto num_domains = communication::global_policy::size();
         auto domain_id = communication::global_policy::id();
 
-        // partition the cells globally across the domains
+        // Partition the cells globally across the domains.
         num_global_cells_ = rec.num_cells();
         cell_begin_ = (cell_gid_type)(num_global_cells_*(domain_id/(double)num_domains));
         cell_end_ = (cell_gid_type)(num_global_cells_*((domain_id+1)/(double)num_domains));
 
-        // partition the local cells into cell groups
+        // Partition the local cells into cell groups that satisfy three
+        // criteria:
+        //  1. the cells in a group have contiguous gid
+        //  2. the size of a cell group does not exceed rules.target_group_size;
+        //  3. all cells in a cell group have the same cell_kind.
+        // This simple greedy algorithm appends contiguous cells to a cell
+        // group until either the target group size is reached, or a cell with a
+        // different kind is encountered.
+        // On completion, cell_starts_ partitions the local gid into cell
+        // groups, and group_kinds_ records the cell kind in each cell group.
         if (num_local_cells()>0) {
-            cell_gid_type group_size = 1;
+            cell_size_type group_size = 1;
+
+            // 1st group starts at cell_begin_
             group_starts_.push_back(cell_begin_);
             auto group_kind = rec.get_cell_kind(cell_begin_);
+
+            // set kind for 1st group
             group_kinds_.push_back(group_kind);
+
             cell_gid_type gid = cell_begin_+1;
             while (gid<cell_end_) {
                 auto kind = rec.get_cell_kind(gid);
+
+                // Test if gid belongs to a new cell group, i.e. whether it has
+                // a new cell_kind or if the target group size has been reached.
                 if (kind!=group_kind || group_size>=rules.target_group_size) {
                     group_starts_.push_back(gid);
                     group_kinds_.push_back(kind);
@@ -60,52 +83,65 @@ public:
         }
     }
 
-    util::optional<cell_gid_type> local_group_from_gid(cell_gid_type i) {
+    /// Returns the local index of the cell_group that contains a cell with
+    /// with gid.
+    /// If the cell is not on the local domain, the optional return value is
+    /// not set.
+    util::optional<cell_size_type>
+    local_group_from_gid(cell_gid_type gid) const {
         // check if gid is a local cell
-        if (!is_local_gid(i)) {
+        if (!is_local_gid(gid)) {
             return util::nothing;
         }
-        return gid_group_partition().index(i);
+        return gid_group_partition().index(gid);
     }
 
+    /// Returns the gid of the first cell on the local domain.
     cell_gid_type cell_begin() const {
         return cell_begin_;
     }
 
+    /// Returns one past the gid of the last cell in the local domain.
     cell_gid_type cell_end() const {
         return cell_end_;
     }
 
-    cell_gid_type num_global_cells() const {
+    /// Returns the total number of cells in the global model.
+    cell_size_type num_global_cells() const {
         return num_global_cells_;
     }
 
-    cell_gid_type num_local_cells() const {
+    /// Returns the number of cells on the local domain.
+    cell_size_type num_local_cells() const {
         return cell_end()-cell_begin();
     }
 
-    cell_gid_type num_local_groups() const {
+    /// Returns the number of cell groups on the local domain.
+    cell_size_type num_local_groups() const {
         return group_kinds_.size();
     }
 
-    group_range_type get_group(std::size_t i) const {
+    /// Returns meta data for a local cell group.
+    group_range_type get_group(cell_size_type i) const {
         return {group_starts_[i], group_starts_[i+1], group_kinds_[i]};
     }
 
+    /// Tests whether a gid is on the local domain.
     bool is_local_gid(cell_gid_type i) const {
         return i>=cell_begin_ && i<cell_end_;
     }
 
-    auto gid_group_partition() -> decltype(util::partition_view(std::vector<cell_gid_type>())) const {
+    gid_partition_type gid_group_partition() const {
         return util::partition_view(group_starts_);
     }
 
 private:
 
+    backend_policy backend_policy_;
     cell_gid_type cell_begin_;
     cell_gid_type cell_end_;
-    cell_gid_type num_global_cells_;
-    std::vector<cell_gid_type> group_starts_;
+    cell_size_type num_global_cells_;
+    std::vector<cell_size_type> group_starts_;
     std::vector<cell_kind> group_kinds_;
 };
 

--- a/src/model.hpp
+++ b/src/model.hpp
@@ -13,6 +13,7 @@
 #include <cell_group.hpp>
 #include <communication/communicator.hpp>
 #include <communication/global_policy.hpp>
+#include <domain_decomposition.hpp>
 #include <mc_cell_group.hpp>
 #include <profiling/profiler.hpp>
 #include <recipe.hpp>
@@ -44,17 +45,19 @@ public:
     };
 
     template <typename Iter>
-    model( const recipe& rec,
-           const util::partition_range<Iter>& groups,
-           backend_policy policy):
-        cell_group_divisions_(groups.divisions().begin(), groups.divisions().end()),
+    model(const recipe& rec, backend_policy policy):
         backend_policy_(policy)
     {
+        // perform domaint decomposition
+        // TODO:
+
         // set up communicator based on partition
+        // TODO: gid_partition
         communicator_ = communicator_type(gid_partition());
 
         // generate the cell groups in parallel, with one task per cell group
-        cell_groups_.resize(gid_partition().size());
+        cell_groups_.resize(domain_.num_local_groups());
+
         // thread safe vector for constructing the list of probes in parallel
         threading::parallel_vector<probe_record> probe_tmp;
 
@@ -62,11 +65,11 @@ public:
             [&](cell_gid_type i) {
                 PE("setup", "cells");
 
-                auto gids = gid_partition()[i];
-                std::vector<cell> cells{gids.second-gids.first};
+                auto gids = domain_.get_group(i);
+                std::vector<cell> cells{gids.from-gids.to};
 
-                for (auto gid: util::make_span(gids)) {
-                    auto i = gid-gids.first;
+                for (auto gid: util::make_span(gids.from, gids.to)) {
+                    auto i = gid-gids.from;
                     cells[i] = rec.get_cell(gid);
 
                     cell_lid_type j = 0;
@@ -77,10 +80,10 @@ public:
                 }
 
                 if (backend_policy_==backend_policy::use_multicore) {
-                    cell_groups_[i] = make_cell_group<multicore_lowered_cell>(gids.first, cells);
+                    cell_groups_[i] = make_cell_group<multicore_lowered_cell>(gids.from, cells);
                 }
                 else {
-                    cell_groups_[i] = make_cell_group<gpu_lowered_cell>(gids.first, cells);
+                    cell_groups_[i] = make_cell_group<gpu_lowered_cell>(gids.from, cells);
                 }
                 PL(2);
             });
@@ -89,7 +92,7 @@ public:
         probes_.assign(probe_tmp.begin(), probe_tmp.end());
 
         // generate the network connections
-        for (cell_gid_type i: util::make_span(gid_partition().bounds())) {
+        for (cell_gid_type i: util::make_span(domain_.first_cell(), domain_.last_cell())) {
             for (const auto& cc: rec.connections_on(i)) {
                 connection conn{cc.source, cc.dest, cc.weight, cc.delay};
                 communicator_.add_connection(conn);
@@ -106,7 +109,8 @@ public:
 
     // one cell per group:
     model(const recipe& rec, backend_policy policy):
-        model(rec, util::partition_view(util::make_span(0, rec.num_cells()+1)), policy)
+        model(rec, policy) // TODO
+        //model(rec, util::partition_view(util::make_span(0, rec.num_cells()+1)), policy)
     {}
 
     void reset() {
@@ -224,12 +228,12 @@ public:
     }
 
     void attach_sampler(cell_member_type probe_id, sampler_function f, time_type tfrom = 0) {
-        if (!algorithms::in_interval(probe_id.gid, gid_partition().bounds())) {
-            return;
-        }
+        const auto idx = domain_.local_group_from_gid(probe_id.gid);
 
-        const auto idx = gid_partition().index(probe_id.gid);
-        cell_groups_[idx]->add_sampler(probe_id, f, tfrom);
+        // only attach samplers for local cells
+        if (idx) {
+            cell_groups_[*idx]->add_sampler(probe_id, f, tfrom);
+        }
     }
 
     const std::vector<probe_record>& probes() const { return probes_; }
@@ -243,8 +247,7 @@ public:
     }
 
     std::size_t num_cells() const {
-        auto bounds = gid_partition().bounds();
-        return bounds.second-bounds.first;
+        return domain_.num_local_cells();
     }
 
     // Set event binning policy on all our groups.
@@ -272,12 +275,8 @@ public:
     }
 
 private:
-    std::vector<cell_gid_type> cell_group_divisions_;
+    domain_decomposition domain_;
     backend_policy backend_policy_;
-
-    auto gid_partition() const -> decltype(util::partition_view(cell_group_divisions_)) {
-        return util::partition_view(cell_group_divisions_);
-    }
 
     time_type t_ = 0.;
     std::vector<std::unique_ptr<cell_group>> cell_groups_;

--- a/src/model.hpp
+++ b/src/model.hpp
@@ -49,7 +49,7 @@ public:
         backend_policy_(rules.policy)
     {
         // set up communicator based on partition
-        communicator_ = communicator_type(domain_.local_gid_partition());
+        communicator_ = communicator_type(domain_.gid_group_partition());
 
         // generate the cell groups in parallel, with one task per cell group
         cell_groups_.resize(domain_.num_local_groups());
@@ -88,7 +88,7 @@ public:
         probes_.assign(probe_tmp.begin(), probe_tmp.end());
 
         // generate the network connections
-        for (cell_gid_type i: util::make_span(domain_.first_cell(), domain_.last_cell())) {
+        for (cell_gid_type i: util::make_span(domain_.cell_begin(), domain_.cell_end())) {
             for (const auto& cc: rec.connections_on(i)) {
                 connection conn{cc.source, cc.dest, cc.weight, cc.delay};
                 communicator_.add_connection(conn);

--- a/src/model.hpp
+++ b/src/model.hpp
@@ -74,7 +74,7 @@ public:
                     }
                 }
 
-                if (backend_policy_==backend_policy::use_multicore) {
+                if (domain_.backend()==backend_policy::use_multicore) {
                     cell_groups_[i] = make_cell_group<multicore_lowered_cell>(gids.begin, cells);
                 }
                 else {
@@ -267,7 +267,6 @@ public:
 
 private:
     const domain_decomposition &domain_;
-    backend_policy backend_policy_;
 
     time_type t_ = 0.;
     std::vector<std::unique_ptr<cell_group>> cell_groups_;

--- a/src/recipe.hpp
+++ b/src/recipe.hpp
@@ -4,6 +4,8 @@
 #include <memory>
 #include <stdexcept>
 
+#include <cell.hpp>
+
 namespace nest {
 namespace mc {
 

--- a/src/util/meta.hpp
+++ b/src/util/meta.hpp
@@ -187,10 +187,6 @@ struct common_random_access_iterator<
 template <typename I, typename E>
 using common_random_access_iterator_t = typename common_random_access_iterator<I, E>::type;
 
-//
-// TODO : now that we are using gcc 5+, replace these old skool SFINAE thingys
-//
-
 namespace impl {
     /// Helper for SFINAE tests that can "sink" any type
     template<typename T>

--- a/tests/global_communication/CMakeLists.txt
+++ b/tests/global_communication/CMakeLists.txt
@@ -2,6 +2,7 @@ set(HEADERS
     ${PROJECT_SOURCE_DIR}/src/swcio.hpp
 )
 set(COMMUNICATION_SOURCES
+    test_domain_decomposition.cpp
     test_exporter_spike_file.cpp
     test_communicator.cpp
     test_mpi_gather_all.cpp

--- a/tests/global_communication/test_communicator.cpp
+++ b/tests/global_communication/test_communicator.cpp
@@ -13,7 +13,7 @@ using namespace nest::mc;
 
 using communicator_type = communication::communicator<communication::global_policy>;
 
-bool is_dry_run() {
+static bool is_dry_run() {
     return communication::global_policy::kind() ==
         communication::global_policy_kind::dryrun;
 }

--- a/tests/global_communication/test_domain_decomposition.cpp
+++ b/tests/global_communication/test_domain_decomposition.cpp
@@ -1,0 +1,30 @@
+#include "../gtest.h"
+
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <communication/communicator.hpp>
+#include <communication/global_policy.hpp>
+
+using namespace nest::mc;
+
+using communicator_type = communication::communicator<communication::global_policy>;
+
+static bool is_dry_run() {
+    return communication::global_policy::kind() ==
+        communication::global_policy_kind::dryrun;
+}
+
+TEST(domain_decomp, basic) {
+    using policy = communication::global_policy;
+
+/*
+    const auto num_domains = policy::size();
+    const auto rank = policy::id();
+*/
+
+
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -37,6 +37,7 @@ set(TEST_SOURCES
     test_compartments.cpp
     test_counter.cpp
     test_cycle.cpp
+    test_domain_decomposition.cpp
     test_either.cpp
     test_event_queue.cpp
     test_event_binner.cpp

--- a/tests/unit/test_domain_decomposition.cpp
+++ b/tests/unit/test_domain_decomposition.cpp
@@ -54,8 +54,8 @@ TEST(domain_decomposition, one_cell_groups)
     // cell group indexes are monotonically increasing
     for (unsigned i=0u; i<num_cells; ++i) {
         auto g = decomp.get_group(i);
-        EXPECT_LT(g.from, g.to);
-        EXPECT_EQ(g.to-g.from, 1u);
+        EXPECT_LT(g.begin, g.end);
+        EXPECT_EQ(g.end-g.begin, 1u);
     }
 
     // check that local gid are identified as local
@@ -86,11 +86,11 @@ TEST(domain_decomposition, multi_cell_groups)
         unsigned total_cells = 0;
         for (auto i=0u; i<num_groups; ++i) {
             auto g = decomp.get_group(i);
-            auto size = g.to-g.from;
+            auto size = g.end-g.begin;
 
             // assert that size of the group:
             //   is nonzero
-            EXPECT_LT(g.from, g.to);
+            EXPECT_LT(g.begin, g.end);
             //   is no larger than group_size
             EXPECT_TRUE(size<=group_size);
 

--- a/tests/unit/test_domain_decomposition.cpp
+++ b/tests/unit/test_domain_decomposition.cpp
@@ -84,6 +84,7 @@ TEST(domain_decomposition, multi_cell_groups)
 
         // check that cell group indexes are monotonically increasing
         unsigned total_cells = 0;
+        std::vector<cell_size_type> bounds{decomp.cell_begin()};
         for (auto i=0u; i<num_groups; ++i) {
             auto g = decomp.get_group(i);
             auto size = g.end-g.begin;
@@ -93,6 +94,11 @@ TEST(domain_decomposition, multi_cell_groups)
             EXPECT_LT(g.begin, g.end);
             //   is no larger than group_size
             EXPECT_TRUE(size<=group_size);
+
+            // Check that the start of this group matches the end of
+            // the preceding group.
+            EXPECT_EQ(bounds.back(), g.begin);
+            bounds.push_back(g.end);
 
             total_cells += size;
         }

--- a/tests/unit/test_domain_decomposition.cpp
+++ b/tests/unit/test_domain_decomposition.cpp
@@ -1,0 +1,112 @@
+#include "../gtest.h"
+
+#include <domain_decomposition.hpp>
+#include <backends.hpp>
+
+using namespace nest::mc;
+
+namespace {
+
+// dummy recipe type for testing
+class test_recipe: public recipe {
+public:
+    test_recipe(cell_size_type s): size_(s)
+    {}
+
+    cell_size_type num_cells() const override {
+        return size_;
+    }
+
+    cell get_cell(cell_gid_type) const override {
+        return cell();
+    }
+    cell_kind get_cell_kind(cell_gid_type) const override {
+        return cell_kind::cable1d_neuron;
+    }
+
+    cell_count_info get_cell_count_info(cell_gid_type) const override {
+        return {0, 0, 0};
+    }
+    std::vector<cell_connection> connections_on(cell_gid_type) const override {
+        return {};
+    }
+
+private:
+    cell_size_type size_;
+};
+
+}
+
+TEST(domain_decomposition, one_cell_groups)
+{
+    group_rules rules{1, backend_policy::use_multicore};
+
+    unsigned num_cells = 10;
+    domain_decomposition decomp(test_recipe(num_cells), rules);
+
+    EXPECT_EQ(0u, decomp.first_cell());
+    EXPECT_EQ(num_cells, decomp.last_cell());
+
+    EXPECT_EQ(num_cells, decomp.num_local_cells());
+    EXPECT_EQ(num_cells, decomp.num_global_cells());
+    EXPECT_EQ(num_cells, decomp.num_local_groups());
+
+    // cell group indexes are monotonically increasing
+    for (unsigned i=0u; i<num_cells; ++i) {
+        auto g = decomp.get_group(i);
+        EXPECT_LT(g.from, g.to);
+        EXPECT_EQ(g.to-g.from, 1u);
+    }
+
+    // check that local gid are identified as local
+    for (auto i=0u; i<num_cells; ++i) {
+        EXPECT_TRUE(decomp.is_local_gid(i));
+    }
+    EXPECT_FALSE(decomp.is_local_gid(num_cells));
+}
+
+TEST(domain_decomposition, multi_cell_groups)
+{
+    unsigned num_cells = 10;
+
+    // test group sizes from 1 up to 1 more than the total number of cells
+    for (unsigned group_size=1u; group_size<=num_cells+1; ++group_size) {
+        group_rules rules{group_size, backend_policy::use_multicore};
+        domain_decomposition decomp(test_recipe(num_cells), rules);
+
+        EXPECT_EQ(0u, decomp.first_cell());
+        EXPECT_EQ(num_cells, decomp.last_cell());
+
+        EXPECT_EQ(num_cells, decomp.num_local_cells());
+        EXPECT_EQ(num_cells, decomp.num_global_cells());
+
+        unsigned num_groups = decomp.num_local_groups();
+
+        // check that cell group indexes are monotonically increasing
+        unsigned total_cells = 0;
+        for (auto i=0u; i<num_groups; ++i) {
+            auto g = decomp.get_group(i);
+            auto size = g.to-g.from;
+
+            // assert that size of the group:
+            //   is nonzero
+            EXPECT_LT(g.from, g.to);
+            //   is no larger than group_size
+            EXPECT_TRUE(size<=group_size);
+
+            total_cells += size;
+        }
+        // check that the sum of the group sizes euqals the total number of cells
+        EXPECT_EQ(total_cells, num_cells);
+
+        // check that local gid are identified as local
+        for (auto i=0u; i<num_cells; ++i) {
+            EXPECT_TRUE(decomp.is_local_gid(i));
+            auto group_id = decomp.local_group_from_gid(i);
+            EXPECT_TRUE(group_id);
+            EXPECT_LT(*group_id, num_groups);
+        }
+        EXPECT_FALSE(decomp.is_local_gid(num_cells));
+        EXPECT_FALSE(decomp.local_group_from_gid(num_cells));
+    }
+}

--- a/tests/unit/test_domain_decomposition.cpp
+++ b/tests/unit/test_domain_decomposition.cpp
@@ -44,8 +44,8 @@ TEST(domain_decomposition, one_cell_groups)
     unsigned num_cells = 10;
     domain_decomposition decomp(test_recipe(num_cells), rules);
 
-    EXPECT_EQ(0u, decomp.first_cell());
-    EXPECT_EQ(num_cells, decomp.last_cell());
+    EXPECT_EQ(0u, decomp.cell_begin());
+    EXPECT_EQ(num_cells, decomp.cell_end());
 
     EXPECT_EQ(num_cells, decomp.num_local_cells());
     EXPECT_EQ(num_cells, decomp.num_global_cells());
@@ -74,8 +74,8 @@ TEST(domain_decomposition, multi_cell_groups)
         group_rules rules{group_size, backend_policy::use_multicore};
         domain_decomposition decomp(test_recipe(num_cells), rules);
 
-        EXPECT_EQ(0u, decomp.first_cell());
-        EXPECT_EQ(num_cells, decomp.last_cell());
+        EXPECT_EQ(0u, decomp.cell_begin());
+        EXPECT_EQ(num_cells, decomp.cell_end());
 
         EXPECT_EQ(num_cells, decomp.num_local_cells());
         EXPECT_EQ(num_cells, decomp.num_global_cells());

--- a/tests/validation/validate_ball_and_stick.hpp
+++ b/tests/validation/validate_ball_and_stick.hpp
@@ -49,7 +49,7 @@ void run_ncomp_convergence_test(
                 seg->set_compartments(ncomp);
             }
         }
-        model m(singleton_recipe{c}, backend);
+        model m(singleton_recipe{c}, {1u, backend});
 
         runner.run(m, ncomp, t_end, dt, exclude);
     }

--- a/tests/validation/validate_ball_and_stick.hpp
+++ b/tests/validation/validate_ball_and_stick.hpp
@@ -49,7 +49,8 @@ void run_ncomp_convergence_test(
                 seg->set_compartments(ncomp);
             }
         }
-        model m(singleton_recipe{c}, {1u, backend});
+        domain_decomposition decomp(singleton_recipe{c}, {1u, backend});
+        model m(singleton_recipe{c}, decomp);
 
         runner.run(m, ncomp, t_end, dt, exclude);
     }

--- a/tests/validation/validate_kinetic.hpp
+++ b/tests/validation/validate_kinetic.hpp
@@ -32,7 +32,7 @@ void run_kinetic_dt(
     convergence_test_runner<float> runner("dt", samplers, meta);
     runner.load_reference_data(ref_file);
 
-    model model(singleton_recipe{c}, backend);
+    model model(singleton_recipe{c}, {1u, backend});
 
     auto exclude = stimulus_ends(c);
 

--- a/tests/validation/validate_kinetic.hpp
+++ b/tests/validation/validate_kinetic.hpp
@@ -32,7 +32,8 @@ void run_kinetic_dt(
     convergence_test_runner<float> runner("dt", samplers, meta);
     runner.load_reference_data(ref_file);
 
-    model model(singleton_recipe{c}, {1u, backend});
+    domain_decomposition decomp(singleton_recipe{c}, {1u, backend});
+    model model(singleton_recipe{c}, decomp);
 
     auto exclude = stimulus_ends(c);
 

--- a/tests/validation/validate_soma.hpp
+++ b/tests/validation/validate_soma.hpp
@@ -18,7 +18,8 @@ void validate_soma(nest::mc::backend_policy backend) {
 
     cell c = make_cell_soma_only();
     add_common_voltage_probes(c);
-    model model(singleton_recipe{c}, {1u, backend});
+    domain_decomposition decomp(singleton_recipe{c}, {1u, backend});
+    model m(singleton_recipe{c}, decomp);
 
     float sample_dt = .025f;
     sampler_info samplers[] = {{"soma.mid", {0u, 0u}, simple_sampler(sample_dt)}};
@@ -43,9 +44,9 @@ void validate_soma(nest::mc::backend_policy backend) {
             double oo_dt = base/multiple;
             if (oo_dt>max_oo_dt) goto end;
 
-            model.reset();
+            m.reset();
             float dt = float(1./oo_dt);
-            runner.run(model, dt, t_end, dt, {});
+            runner.run(m, dt, t_end, dt, {});
         }
     }
 end:

--- a/tests/validation/validate_soma.hpp
+++ b/tests/validation/validate_soma.hpp
@@ -18,7 +18,7 @@ void validate_soma(nest::mc::backend_policy backend) {
 
     cell c = make_cell_soma_only();
     add_common_voltage_probes(c);
-    model model(singleton_recipe{c}, backend);
+    model model(singleton_recipe{c}, {1u, backend});
 
     float sample_dt = .025f;
     sampler_info samplers[] = {{"soma.mid", {0u, 0u}, simple_sampler(sample_dt)}};

--- a/tests/validation/validate_synapses.hpp
+++ b/tests/validation/validate_synapses.hpp
@@ -60,7 +60,8 @@ void run_synapse_test(
 
     for (int ncomp = 10; ncomp<max_ncomp; ncomp*=2) {
         c.cable(1)->set_compartments(ncomp);
-        model m(singleton_recipe{c}, {1u, backend});
+        domain_decomposition decomp(singleton_recipe{c}, {1u, backend});
+        model m(singleton_recipe{c}, decomp);
         m.group(0).enqueue_events(synthetic_events);
 
         runner.run(m, ncomp, t_end, dt, exclude);

--- a/tests/validation/validate_synapses.hpp
+++ b/tests/validation/validate_synapses.hpp
@@ -60,7 +60,7 @@ void run_synapse_test(
 
     for (int ncomp = 10; ncomp<max_ncomp; ncomp*=2) {
         c.cable(1)->set_compartments(ncomp);
-        model m(singleton_recipe{c}, backend);
+        model m(singleton_recipe{c}, {1u, backend});
         m.group(0).enqueue_events(synthetic_events);
 
         runner.run(m, ncomp, t_end, dt, exclude);


### PR DESCRIPTION
The domain decomposition, whereby cells were partitioned across domains/MPI
ranks and then grouped together, was performed in an ad-hoc manner.
This PR modularizes the domain decomposition.

* A `domain_decomposition` class performs the cell partitioning given the recipe
  and some parameters.
* This implementation has a single `domain_decomposition` class and flags are 
  provided in a `group_rules` struct
  * The `domain_decomposition` could be specialized, or the simple rules struct
    could provide some sort of policy implementation in the future when the 
    need arises
* The domain_decomposition class is initialized inside the model constructor
  and is maintained as state of the model.
* The cell model constructor interface has been simplified to a single constructor
  that takes a recipe and a reference to a `domain_decomposition`.
  * In the future we might pass in only a moveable subset of the 
    `domain_decomposition` information required to build the model.                                      

fixes #242.