### PR TITLE
Fix warnings and errors with icpc build.

### DIFF
--- a/src/cell.hpp
+++ b/src/cell.hpp
@@ -100,7 +100,7 @@ public:
      }
 
     /// Return the kind of cell, used for grouping into cell_groups
-    cell_kind const get_cell_kind() const  {
+    cell_kind get_cell_kind() const  {
         return cell_kind::cable1d_neuron;
     }
 

--- a/src/cell_group.hpp
+++ b/src/cell_group.hpp
@@ -18,7 +18,7 @@ class cell_group {
 public:
     virtual ~cell_group() = default;
 
-    virtual cell_kind const get_cell_kind() const = 0;
+    virtual cell_kind get_cell_kind() const = 0;
 
     virtual void reset() = 0;
     virtual void set_binning_policy(binning_kind policy, time_type bin_interval) = 0;

--- a/src/mc_cell_group.hpp
+++ b/src/mc_cell_group.hpp
@@ -61,7 +61,7 @@ public:
         EXPECTS(spike_sources_.size()==n_detectors);
     }
 
-    cell_kind const get_cell_kind() const override {
+    cell_kind get_cell_kind() const override {
         return cell_kind::cable1d_neuron;
     }
 

--- a/src/util/strprintf.hpp
+++ b/src/util/strprintf.hpp
@@ -6,6 +6,7 @@
 #include <cstdio>
 #include <memory>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
Fixes #245.

* Add missing header <system_error> to `src/util/strprintf.hpp`
* Remove redundant `const` in `cell_kind` returns.