### PR TITLE
Feature/any

### DIFF
--- a/src/util/any.hpp
+++ b/src/util/any.hpp
@@ -4,8 +4,6 @@
 #include <typeinfo>
 #include <type_traits>
 
-#include <iostream> // TODO: remove
-
 #include <util/meta.hpp>
 
 // Partial implementation of std::any from C++17 standard.
@@ -16,8 +14,6 @@
 // - Does not avoid dynamic allocation of small objects.
 // - Does not implement the in_place_type<T> constructors from the standard.
 // - Does not implement the emplace modifier from the standard.
-// - Does not implement the make_any non-member function from the standard.
-//
 
 namespace nest {
 namespace mc {
@@ -220,6 +216,14 @@ T any_cast(any&& operand) {
 
 // Constructs an any object containing an object of type T, passing the
 // provided arguments to T's constructor.
+//
+// This does not exactly follow the standard, which states that
+// make_any is equivalent to
+//   return std::any(std::in_place_type<T>, std::forward<Args>(args)...);
+// i.e. that the contained object should be constructed in place, whereas
+// this implementation constructs the object, then moves it into the
+// contained object.
+// FIXME: rewrite with in_place_type when available.
 template <class T, class... Args>
 any make_any(Args&&... args) {
     return any(T(std::forward<Args>(args) ...));

--- a/src/util/any.hpp
+++ b/src/util/any.hpp
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <memory>
+#include <typeinfo>
+#include <type_traits>
+
+#include <util/meta.hpp>
+
+// Partial implementation of std::any from C++17 standard.
+//      http://en.cppreference.com/w/cpp/utility/any
+//
+// Implements a standard-compliant subset of the full interface.
+//
+// Does not attempt to avoid dynamic allocation of small objects.
+
+
+namespace nest {
+namespace mc {
+namespace util {
+
+class any {
+public:
+    constexpr any() = default;
+
+    any(const any& other):
+        state_(other.state_->copy())
+    {}
+
+    any(any&& other) {
+        std::swap(other.state_, state_);
+    }
+
+    // any uses value semantics
+    template <
+        typename T,
+        typename = typename
+            util::enable_if_t<!std::is_same<util::decay_t<T>, any>::value>
+    >
+    any(T&& other):
+        state_(new model<util::decay_t<T>>(std::forward<T>(other)))
+    {}
+
+    bool has_value() const {
+        return (bool)state_;
+    }
+
+    const std::type_info& type() const {
+        return state_->type();
+    }
+
+private:
+
+    struct concept {
+        virtual ~concept() = default;
+
+        // TODO: comments
+        virtual const std::type_info& type() = 0;
+        virtual concept* copy() = 0;
+        //virtual void swap(concept& other) = 0;
+        //void(*move)(storage_union& src, storage_union& dest) noexcept;
+    };
+
+    template <typename T>
+    struct model: public concept {
+        ~model() = default;
+
+        concept* copy() override {
+            return new model<T>(*this);
+        }
+
+        const std::type_info& type() override {
+            return typeid(T);
+        }
+
+        model(const T& other):
+            value(other)
+        {}
+
+        model(T&& other):
+            value(std::move(other))
+        {}
+
+        T value;
+    };
+
+    std::unique_ptr<concept> state_;
+};
+
+template<class T>
+T any_cast(const any& operand) {
+
+}
+
+/*
+template<class T>
+T any_cast(any& operand);
+
+template<class T>
+T any_cast(any&& operand);
+
+template<class T>
+const T* any_cast(const any* operand);
+
+template<class T>
+T* any_cast(any* operand);
+*/
+
+} // namespace util
+} // namespace mc
+} // namespace nest

--- a/src/util/any.hpp
+++ b/src/util/any.hpp
@@ -15,9 +15,9 @@
 //
 // - Does not avoid dynamic allocation of small objects.
 // - Does not implement the in_place_type<T> constructors from the standard.
-// - Does not implement the in_place_type<T> constructors from the standard.
+// - Does not implement the emplace modifier from the standard.
+// - Does not implement the make_any non-member function from the standard.
 //
-
 
 namespace nest {
 namespace mc {
@@ -50,8 +50,7 @@ public:
         typename = typename
             util::enable_if_t<!std::is_same<util::decay_t<T>, any>::value>
     >
-    any(T&& other)
-    {
+    any(T&& other) {
         using contained_type = util::decay_t<T>;
         static_assert(
             std::is_copy_constructible<contained_type>::value,

--- a/src/util/any.hpp
+++ b/src/util/any.hpp
@@ -37,9 +37,7 @@ class any {
 public:
     constexpr any() = default;
 
-    any(const any& other):
-        state_(other.state_->copy())
-    {}
+    any(const any& other): state_(other.state_->copy()) {}
 
     any(any&& other) noexcept {
         std::swap(other.state_, state_);
@@ -47,13 +45,11 @@ public:
 
     template <
         typename T,
-        typename = typename
-            util::enable_if_t<!std::is_same<util::decay_t<T>, any>::value>
+        typename = typename util::enable_if_t<!std::is_same<util::decay_t<T>, any>::value>
     >
     any(T&& other) {
         using contained_type = util::decay_t<T>;
-        static_assert(
-            std::is_copy_constructible<contained_type>::value,
+        static_assert(std::is_copy_constructible<contained_type>::value,
             "Type of contained object stored in any must satisfy the CopyConstructible requirements.");
 
         state_.reset(new model<contained_type>(std::forward<T>(other)));
@@ -71,14 +67,12 @@ public:
 
     template <
         typename T,
-        typename = typename
-            util::enable_if_t<!std::is_same<util::decay_t<T>, any>::value>
+        typename = typename util::enable_if_t<!std::is_same<util::decay_t<T>, any>::value>
     >
     any& operator=(T&& other) {
         using contained_type = util::decay_t<T>;
 
-        static_assert(
-            std::is_copy_constructible<contained_type>::value,
+        static_assert(std::is_copy_constructible<contained_type>::value,
             "Type of contained object stored in any must satisfy the CopyConstructible requirements.");
 
         state_.reset(new model<contained_type>(std::forward<T>(other)));
@@ -98,11 +92,10 @@ public:
     }
 
     const std::type_info& type() const noexcept {
-        return state_->type();
+        return has_value()? state_->type(): typeid(void);
     }
 
 private:
-
     struct interface {
         virtual ~interface() = default;
         virtual const std::type_info& type() = 0;
@@ -115,6 +108,10 @@ private:
     struct model: public interface {
         ~model() = default;
 
+        model(const T& other): value(other) {}
+
+        model(T&& other): value(std::move(other)) {}
+
         interface* copy() override {
             return new model<T>(*this);
         }
@@ -123,19 +120,11 @@ private:
             return typeid(T);
         }
 
-        model(const T& other):
-            value(other)
-        {}
-
-        model(T&& other):
-            value(std::move(other))
-        {}
-
-        void* pointer() {
+        void* pointer() override {
             return &value;
         }
 
-        const void* pointer() const {
+        const void* pointer() const override {
             return &value;
         }
 
@@ -154,38 +143,21 @@ protected:
 
     template <typename T>
     T* unsafe_cast() {
-        return reinterpret_cast<T*>(state_->pointer());
+        return static_cast<T*>(state_->pointer());
     }
 
     template <typename T>
     const T* unsafe_cast() const {
-        return reinterpret_cast<T*>(state_->pointer());
+        return static_cast<const T*>(state_->pointer());
     }
 };
 
 namespace impl {
-    template <typename T>
-    using any_cast_remove_qual = typename
-        std::remove_cv<typename std::remove_reference<T>::type>::type;
 
-    template <typename ValueType, typename U=any_cast_remove_qual<ValueType>>
-    using test_any_cast_constructable = typename
-        std::conditional<
-               std::is_constructible<ValueType, const U&>::value
-            && std::is_constructible<ValueType, U&>::value
-            && std::is_constructible<ValueType, U>::value,
-            std::true_type,
-            std::false_type>::type;
+template <typename T>
+using any_cast_remove_qual = typename
+    std::remove_cv<typename std::remove_reference<T>::type>::type;
 
-    template<typename T>
-    inline T move_else_copy(any_cast_remove_qual<T>* p, std::true_type) {
-        return std::move(*p);
-    }
-
-    template<typename T>
-    inline T move_else_copy(any_cast_remove_qual<T>* p, std::false_type) {
-        return *p;
-    }
 } // namespace impl
 
 // If operand is not a null pointer, and the typeid of the requested T matches
@@ -193,44 +165,26 @@ namespace impl {
 // otherwise a null pointer.
 template<class T>
 const T* any_cast(const any* operand) {
-    static_assert(
-        impl::test_any_cast_constructable<T>::value,
-        "any_cast requires ");
-
-    if (operand==nullptr || !operand->has_value()) {
-        return nullptr;
+    if (operand && operand->type()==typeid(T)) {
+        return operand->unsafe_cast<T>();
     }
-
-    if (operand->type() != typeid(T)) {
-        throw bad_any_cast();
-    }
-
-    return operand->unsafe_cast<T>();
+    return nullptr;
 }
 
-// If operand is not a null pointer, and the typeid of the requested T matches
-// that of the contents of operand, a pointer to the value contained by operand,
-// otherwise a null pointer.
 template<class T>
 T* any_cast(any* operand) {
-    static_assert(
-        impl::test_any_cast_constructable<T>::value,
-        "any_cast can't construct the desired type");
-
-    if (operand==nullptr || !operand->has_value()) {
-        return nullptr;
+    if (operand && operand->type()==typeid(T)) {
+        return operand->unsafe_cast<T>();
     }
-
-    if (operand->type() != typeid(T)) {
-        throw bad_any_cast();
-    }
-
-    return operand->unsafe_cast<T>();
+    return nullptr;
 }
 
 template<class T>
 T any_cast(const any& operand) {
     using U = impl::any_cast_remove_qual<T>;
+    static_assert(std::is_constructible<T, const U&>::value,
+        "any_cast type can't construct copy of contained object");
+
     auto ptr = any_cast<U>(&operand);
     if (ptr==nullptr) {
         throw bad_any_cast();
@@ -241,6 +195,9 @@ T any_cast(const any& operand) {
 template<class T>
 T any_cast(any& operand) {
     using U = impl::any_cast_remove_qual<T>;
+    static_assert(std::is_constructible<T, U&>::value,
+        "any_cast type can't construct copy of contained object");
+
     auto ptr = any_cast<U>(&operand);
     if (ptr==nullptr) {
         throw bad_any_cast();
@@ -251,17 +208,14 @@ T any_cast(any& operand) {
 template<class T>
 T any_cast(any&& operand) {
     using U = impl::any_cast_remove_qual<T>;
-    using do_move = typename
-        std::conditional<
-            std::is_move_constructible<T>::value
-            & !std::is_lvalue_reference<T>::value,
-            std::true_type, std::false_type>::type;
+    static_assert(std::is_constructible<T, U>::value,
+        "any_cast type can't construct copy of contained object");
 
     auto ptr = any_cast<U>(&operand);
     if (ptr==nullptr) {
         throw bad_any_cast();
     }
-    return impl::move_else_copy<T>(static_cast<T*>(ptr), do_move());
+    return static_cast<T>(std::move(*ptr));
 }
 
 } // namespace util

--- a/src/util/any.hpp
+++ b/src/util/any.hpp
@@ -4,6 +4,8 @@
 #include <typeinfo>
 #include <type_traits>
 
+#include <iostream> // TODO: remove
+
 #include <util/meta.hpp>
 
 // Partial implementation of std::any from C++17 standard.
@@ -11,12 +13,25 @@
 //
 // Implements a standard-compliant subset of the full interface.
 //
-// Does not attempt to avoid dynamic allocation of small objects.
+// - Does not avoid dynamic allocation of small objects.
+// - Does not implement the in_place_type<T> constructors from the standard.
+// - Does not implement the in_place_type<T> constructors from the standard.
+//
 
 
 namespace nest {
 namespace mc {
 namespace util {
+
+// Defines a type of object to be thrown by the value-returning forms of
+// util::any_cast on failure.
+//      http://en.cppreference.com/w/cpp/utility/any/bad_any_cast
+class bad_any_cast: public std::bad_cast {
+public:
+    const char* what() const noexcept override {
+        return "bad any cast";
+    }
+};
 
 class any {
 public:
@@ -26,45 +41,82 @@ public:
         state_(other.state_->copy())
     {}
 
-    any(any&& other) {
+    any(any&& other) noexcept {
         std::swap(other.state_, state_);
     }
 
-    // any uses value semantics
     template <
         typename T,
         typename = typename
             util::enable_if_t<!std::is_same<util::decay_t<T>, any>::value>
     >
-    any(T&& other):
-        state_(new model<util::decay_t<T>>(std::forward<T>(other)))
-    {}
+    any(T&& other)
+    {
+        using contained_type = util::decay_t<T>;
+        static_assert(
+            std::is_copy_constructible<contained_type>::value,
+            "Type of contained object stored in any must satisfy the CopyConstructible requirements.");
 
-    bool has_value() const {
+        state_.reset(new model<contained_type>(std::forward<T>(other)));
+    }
+
+    any& operator=(const any& other) {
+        state_.reset(other.state_->copy());
+        return *this;
+    }
+
+    any& operator=(any&& other) noexcept {
+        swap(other);
+        return *this;
+    }
+
+    template <
+        typename T,
+        typename = typename
+            util::enable_if_t<!std::is_same<util::decay_t<T>, any>::value>
+    >
+    any& operator=(T&& other) {
+        using contained_type = util::decay_t<T>;
+
+        static_assert(
+            std::is_copy_constructible<contained_type>::value,
+            "Type of contained object stored in any must satisfy the CopyConstructible requirements.");
+
+        state_.reset(new model<contained_type>(std::forward<T>(other)));
+        return *this;
+    }
+
+    void reset() noexcept {
+        state_.reset(nullptr);
+    }
+
+    void swap(any& other) noexcept {
+        std::swap(other.state_, state_);
+    }
+
+    bool has_value() const noexcept {
         return (bool)state_;
     }
 
-    const std::type_info& type() const {
+    const std::type_info& type() const noexcept {
         return state_->type();
     }
 
 private:
 
-    struct concept {
-        virtual ~concept() = default;
-
-        // TODO: comments
+    struct interface {
+        virtual ~interface() = default;
         virtual const std::type_info& type() = 0;
-        virtual concept* copy() = 0;
-        //virtual void swap(concept& other) = 0;
-        //void(*move)(storage_union& src, storage_union& dest) noexcept;
+        virtual interface* copy() = 0;
+        virtual void* pointer() = 0;
+        virtual const void* pointer() const = 0;
     };
 
     template <typename T>
-    struct model: public concept {
+    struct model: public interface {
         ~model() = default;
 
-        concept* copy() override {
+        interface* copy() override {
             return new model<T>(*this);
         }
 
@@ -80,30 +132,138 @@ private:
             value(std::move(other))
         {}
 
+        void* pointer() {
+            return &value;
+        }
+
+        const void* pointer() const {
+            return &value;
+        }
+
         T value;
     };
 
-    std::unique_ptr<concept> state_;
+    std::unique_ptr<interface> state_;
+
+protected:
+
+    template <typename T>
+    friend const T* any_cast(const any* operand);
+
+    template <typename T>
+    friend T* any_cast(any* operand);
+
+    template <typename T>
+    T* unsafe_cast() {
+        return reinterpret_cast<T*>(state_->pointer());
+    }
+
+    template <typename T>
+    const T* unsafe_cast() const {
+        return reinterpret_cast<T*>(state_->pointer());
+    }
 };
+
+namespace impl {
+    template <typename T>
+    using any_cast_remove_qual = typename
+        std::remove_cv<typename std::remove_reference<T>::type>::type;
+
+    template <typename ValueType, typename U=any_cast_remove_qual<ValueType>>
+    using test_any_cast_constructable = typename
+        std::conditional<
+               std::is_constructible<ValueType, const U&>::value
+            && std::is_constructible<ValueType, U&>::value
+            && std::is_constructible<ValueType, U>::value,
+            std::true_type,
+            std::false_type>::type;
+
+    template<typename T>
+    inline T move_else_copy(any_cast_remove_qual<T>* p, std::true_type) {
+        return std::move(*p);
+    }
+
+    template<typename T>
+    inline T move_else_copy(any_cast_remove_qual<T>* p, std::false_type) {
+        return *p;
+    }
+} // namespace impl
+
+// If operand is not a null pointer, and the typeid of the requested T matches
+// that of the contents of operand, a pointer to the value contained by operand,
+// otherwise a null pointer.
+template<class T>
+const T* any_cast(const any* operand) {
+    static_assert(
+        impl::test_any_cast_constructable<T>::value,
+        "any_cast requires ");
+
+    if (operand==nullptr || !operand->has_value()) {
+        return nullptr;
+    }
+
+    if (operand->type() != typeid(T)) {
+        throw bad_any_cast();
+    }
+
+    return operand->unsafe_cast<T>();
+}
+
+// If operand is not a null pointer, and the typeid of the requested T matches
+// that of the contents of operand, a pointer to the value contained by operand,
+// otherwise a null pointer.
+template<class T>
+T* any_cast(any* operand) {
+    static_assert(
+        impl::test_any_cast_constructable<T>::value,
+        "any_cast can't construct the desired type");
+
+    if (operand==nullptr || !operand->has_value()) {
+        return nullptr;
+    }
+
+    if (operand->type() != typeid(T)) {
+        throw bad_any_cast();
+    }
+
+    return operand->unsafe_cast<T>();
+}
 
 template<class T>
 T any_cast(const any& operand) {
-
+    using U = impl::any_cast_remove_qual<T>;
+    auto ptr = any_cast<U>(&operand);
+    if (ptr==nullptr) {
+        throw bad_any_cast();
+    }
+    return static_cast<T>(*ptr);
 }
 
-/*
 template<class T>
-T any_cast(any& operand);
+T any_cast(any& operand) {
+    using U = impl::any_cast_remove_qual<T>;
+    auto ptr = any_cast<U>(&operand);
+    if (ptr==nullptr) {
+        throw bad_any_cast();
+    }
+    return static_cast<T>(*ptr);
+}
 
 template<class T>
-T any_cast(any&& operand);
+T any_cast(any&& operand) {
+    using U = impl::any_cast_remove_qual<T>;
+    using do_move = typename
+        std::conditional<
+            std::is_move_constructible<T>::value
+            & !std::is_lvalue_reference<T>::value,
+            std::true_type, std::false_type>::type;
 
-template<class T>
-const T* any_cast(const any* operand);
-
-template<class T>
-T* any_cast(any* operand);
-*/
+    auto ptr = any_cast<U>(&operand);
+    if (ptr==nullptr) {
+        throw bad_any_cast();
+    }
+    return impl::move_else_copy<T>(static_cast<T*>(ptr), do_move());
+}
 
 } // namespace util
 } // namespace mc

--- a/src/util/any.hpp
+++ b/src/util/any.hpp
@@ -218,6 +218,13 @@ T any_cast(any&& operand) {
     return static_cast<T>(std::move(*ptr));
 }
 
+// Constructs an any object containing an object of type T, passing the
+// provided arguments to T's constructor.
+template <class T, class... Args>
+any make_any(Args&&... args) {
+    return any(T(std::forward<Args>(args) ...));
+}
+
 } // namespace util
 } // namespace mc
 } // namespace nest

--- a/tests/global_communication/test_domain_decomposition.cpp
+++ b/tests/global_communication/test_domain_decomposition.cpp
@@ -13,15 +13,15 @@ using namespace nest::mc;
 
 using communicator_type = communication::communicator<communication::global_policy>;
 
-static bool is_dry_run() {
+inline bool is_dry_run() {
     return communication::global_policy::kind() ==
         communication::global_policy_kind::dryrun;
 }
 
 TEST(domain_decomp, basic) {
+/*
     using policy = communication::global_policy;
 
-/*
     const auto num_domains = policy::size();
     const auto rank = policy::id();
 */

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -31,6 +31,7 @@ set(TEST_CUDA_SOURCES
 set(TEST_SOURCES
     # unit tests
     test_algorithms.cpp
+    test_any.cpp
     test_backend.cpp
     test_double_buffer.cpp
     test_cell.cpp

--- a/tests/unit/test_any.cpp
+++ b/tests/unit/test_any.cpp
@@ -253,7 +253,57 @@ TEST(any, assignment_from_value) {
     // ensure the value was moved
     EXPECT_EQ(ptr, vec->data());
 
-    // ensure that the vector was copied correctly
+    // ensure that the contents of the vector are unchanged
     std::vector<int> ref{1, 2, 3};
     EXPECT_EQ(ref, *vec);
+}
+
+TEST(any, make_any) {
+    using util::make_any;
+    using util::any_cast;
+
+    {
+        auto a = make_any<int>(42);
+
+        EXPECT_EQ(typeid(int), a.type());
+        EXPECT_EQ(42, any_cast<int>(a));
+    }
+
+    // check casting
+    {
+        auto a = make_any<double>(42u);
+
+        EXPECT_EQ(typeid(double), a.type());
+        EXPECT_EQ(42.0, any_cast<double>(a));
+    }
+
+    // check forwarding of parameters to constructor
+    {
+        // create a string from const char*
+        auto a = make_any<std::string>("hello");
+
+        EXPECT_EQ(any_cast<std::string>(a), std::string("hello"));
+    }
+
+    // test that we make_any correctly forwards rvalue arguments to the constructor
+    // of the contained object.
+    {
+        std::vector<int> tmp{1, 2, 3};
+
+        // take a pointer to the orignal data to later verify
+        // that the value was moved, and not copied.
+        auto ptr = tmp.data();
+
+        auto a = make_any<std::vector<int>>(std::move(tmp));
+
+        auto vec = any_cast<std::vector<int>>(&a);
+
+        // ensure the value was moved
+        EXPECT_EQ(ptr, vec->data());
+
+        // ensure that the contents of the vector are unchanged
+        std::vector<int> ref{1, 2, 3};
+        EXPECT_EQ(ref, *vec);
+    }
+
 }

--- a/tests/unit/test_any.cpp
+++ b/tests/unit/test_any.cpp
@@ -1,0 +1,50 @@
+#include "../gtest.h"
+
+#include <iostream>
+
+#include <util/any.hpp>
+
+using namespace nest::mc;
+
+TEST(any, copy_construction) {
+    util::any any_int(2);
+    EXPECT_EQ(any_int.type(), typeid(int));
+
+    util::any any_float(2.0f);
+    EXPECT_EQ(any_float.type(), typeid(float));
+
+    std::string str = "hello";
+    util::any any_string(str);
+    EXPECT_EQ(any_string.type(), typeid(std::string));
+}
+
+namespace {
+
+    struct moveable {
+        moveable() = default;
+
+        moveable(moveable&& other) {
+            moves = other.moves+1;
+            std::cout << "move " << moves << "\n";
+        }
+
+        moveable(const moveable& other) {
+            copies = other.copies + 1;
+            std::cout << "copy " << copies << "\n";
+        }
+
+        int moves=0;
+        int copies=0;
+    };
+
+}
+
+TEST(any, move_construction) {
+    moveable m;
+
+    util::any copied(m);
+    util::any moved(std::move(m));
+
+    util::any x(copied);
+    util::any y(moved);
+}

--- a/tests/unit/test_any.cpp
+++ b/tests/unit/test_any.cpp
@@ -23,15 +23,13 @@ namespace {
     struct moveable {
         moveable() = default;
 
-        moveable(moveable&& other) {
-            moves = other.moves+1;
-            std::cout << "move " << moves << "\n";
-        }
+        moveable(moveable&& other):
+            moves(other.moves+1), copies(other.copies)
+        {}
 
-        moveable(const moveable& other) {
-            copies = other.copies + 1;
-            std::cout << "copy " << copies << "\n";
-        }
+        moveable(const moveable& other):
+            moves(other.moves), copies(other.copies+1)
+        {}
 
         int moves=0;
         int copies=0;
@@ -45,6 +43,165 @@ TEST(any, move_construction) {
     util::any copied(m);
     util::any moved(std::move(m));
 
-    util::any x(copied);
-    util::any y(moved);
+    // Check that the expected number of copies and moves were performed.
+    // Note that any_cast(any*) is used instead of any_cast(const any&) because
+    // any_cast(const any&) returns a copy.
+    const auto& cref = *util::any_cast<moveable>(&copied);
+    EXPECT_EQ(cref.moves, 0);
+    EXPECT_EQ(cref.copies, 1);
+
+    const auto& mref = *util::any_cast<moveable>(&moved);
+    EXPECT_EQ(mref.moves, 1);
+    EXPECT_EQ(mref.copies, 0);
+
+    // construction by any&& should not make any copies or moves of the
+    // constructed value
+    util::any fin(std::move(moved));
+    EXPECT_FALSE(moved.has_value()); // moved has been moved from and should be empty
+    const auto& fref = *util::any_cast<moveable>(&fin);
+    EXPECT_EQ(fref.moves, 1);
+    EXPECT_EQ(fref.copies, 0);
+
+    const auto value = util::any_cast<moveable>(fin);
+    EXPECT_EQ(value.moves, 1);
+    EXPECT_EQ(value.copies, 1);
+}
+
+TEST(any, swap) {
+    using util::any;
+    using util::any_cast;
+
+    any any1(42);     // integer
+    any any2(3.14);   // double
+
+    EXPECT_EQ(typeid(int),    any1.type());
+    EXPECT_EQ(typeid(double), any2.type());
+
+    any1.swap(any2);
+
+    EXPECT_EQ(any_cast<int>(any2), 42);
+    EXPECT_EQ(any_cast<double>(any1), 3.14);
+
+    EXPECT_EQ(typeid(double), any1.type());
+    EXPECT_EQ(typeid(int),    any2.type());
+
+    any1.swap(any2);
+
+    EXPECT_EQ(any_cast<double>(any2), 3.14);
+    EXPECT_EQ(any_cast<int>(any1), 42);
+
+    EXPECT_EQ(typeid(int),    any1.type());
+    EXPECT_EQ(typeid(double), any2.type());
+}
+
+// test any_cast(any*)
+//   - these have different behavior to any_cast on reference types
+//   - are used by the any_cast on refernce types
+TEST(any, any_cast_ptr) {
+
+    // test that valid pointers are returned for int and std::string types
+
+    util::any ai(42);
+    auto ptr_i = util::any_cast<int>(&ai);
+    EXPECT_EQ(*ptr_i, 42);
+
+    util::any as(std::string("hello"));
+    auto ptr_s = util::any_cast<std::string>(&as);
+    EXPECT_EQ(*ptr_s, "hello");
+
+    // test that exceptions are thrown for invalid casts
+    EXPECT_THROW(util::any_cast<int>(&as), util::bad_any_cast);
+    EXPECT_THROW(util::any_cast<std::string>(&ai), util::bad_any_cast);
+    util::any empty;
+    EXPECT_EQ(util::any_cast<int>(&empty), nullptr);
+}
+
+TEST(any, any_cast_ref) {
+    util::any ai(42);
+    auto i = util::any_cast<int>(ai);
+    EXPECT_EQ(typeid(i), typeid(int));
+    EXPECT_EQ(i, 42);
+}
+
+// test any_cast(any&&)
+TEST(any, any_cast_rvalue) {
+    auto moved = util::any_cast<moveable>(util::any(moveable()));
+    std::cout << "moves and copies: " << moved.moves << " " << moved.copies  << "\n";
+}
+
+TEST(any, std_swap) {
+    util::any a1(42);
+    util::any a2(3.14);
+
+    auto pi = util::any_cast<int>(&a1);
+    auto pd = util::any_cast<double>(&a2);
+
+    std::swap(a1, a2);
+
+    // test that values were swapped
+    EXPECT_EQ(util::any_cast<int>(a2), 42);
+    EXPECT_EQ(util::any_cast<double>(a1), 3.14);
+
+    // test that underlying pointers did not change
+    EXPECT_EQ(pi, util::any_cast<int>(&a2));
+    EXPECT_EQ(pd, util::any_cast<double>(&a1));
+}
+
+// test operator=(const any&)
+TEST(any, assignment_from_lvalue) {
+    using std::string;
+
+    auto str1 = string("one");
+    auto str2 = string("two");
+    util::any a(str1);
+
+    util::any b;
+    b = a; // copy assignment
+
+    // verify that b contains value stored in a
+    EXPECT_EQ(str1, util::any_cast<string>(b));
+
+    // change the value stored in b
+    *util::any_cast<string>(&b) = str2;
+
+    // verify that a is unchanged and that b holds new value
+    EXPECT_EQ(str1, util::any_cast<string>(a));
+    EXPECT_EQ(str2, util::any_cast<string>(b));
+}
+
+// test operator=(any&&)
+TEST(any, assignment_from_rvalue) {
+    using std::string;
+
+    auto str1 = string("one");
+    auto str2 = string("two");
+    util::any a(str1);
+
+    util::any b;
+    b = std::move(a); // move assignment
+
+    EXPECT_EQ(str1, util::any_cast<string>(b));
+
+    EXPECT_EQ(nullptr, util::any_cast<string>(&a));
+}
+
+// test template<typename T> operator=(T&&)
+TEST(any, assignment_from_value) {
+    std::vector<int> tmp{1, 2, 3};
+
+    // take a pointer to the orignal data to later verify
+    // that the value was moved, and not copied.
+    auto ptr = tmp.data();
+
+    util::any a;
+    a = std::move(tmp);
+
+    auto vec = util::any_cast<std::vector<int>>(&a);
+
+    // ensure the value was moved
+    EXPECT_EQ(ptr, vec->data());
+
+    // ensure that the vector was copied correctly
+    std::vector<int> ref{1, 2, 3};
+    EXPECT_EQ(ref, *vec);
 }


### PR DESCRIPTION
Partial implementation of `std::any` from C++17 standard.
     http://en.cppreference.com/w/cpp/utility/any

The implementation is in the `util` library as `util::any`.

Implements a standard-compliant subset of the full interface.

  * Does not avoid dynamic allocation of small objects.
  * Does not implement the `in_place_type<T>` constructors from the standard.
  * Does not implement the `emplace` modifier from the standard.