### PR TITLE
util::unique_any: a non-copyable util::any 

### DIFF
--- a/src/util/any.hpp
+++ b/src/util/any.hpp
@@ -4,8 +4,6 @@
 #include <typeinfo>
 #include <type_traits>
 
-#include <iostream> // TODO: remove
-
 #include <util/meta.hpp>
 
 // Partial implementation of std::any from C++17 standard.
@@ -16,8 +14,6 @@
 // - Does not avoid dynamic allocation of small objects.
 // - Does not implement the in_place_type<T> constructors from the standard.
 // - Does not implement the emplace modifier from the standard.
-// - Does not implement the make_any non-member function from the standard.
-//
 
 namespace nest {
 namespace mc {
@@ -220,6 +216,14 @@ T any_cast(any&& operand) {
 
 // Constructs an any object containing an object of type T, passing the
 // provided arguments to T's constructor.
+//
+// This does not exactly follow the standard, which states that
+// make_any is equivalent to
+//   return std::any(std::in_place_type<T>, std::forward<Args>(args)...);
+// i.e. that the contained object should be constructed in place, whereas
+// this implementation constructs the object, then moves it into the
+// contained object.
+// FIXME: rewrite with in_place_type when available.
 template <class T, class... Args>
 any make_any(Args&&... args) {
     return any(T(std::forward<Args>(args) ...));

--- a/src/util/any.hpp
+++ b/src/util/any.hpp
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <memory>
+#include <typeinfo>
+#include <type_traits>
+
+#include <util/meta.hpp>
+
+// Partial implementation of std::any from C++17 standard.
+//      http://en.cppreference.com/w/cpp/utility/any
+//
+// Implements a standard-compliant subset of the full interface.
+//
+// Does not attempt to avoid dynamic allocation of small objects.
+
+
+namespace nest {
+namespace mc {
+namespace util {
+
+class any {
+public:
+    constexpr any() = default;
+
+    any(const any& other):
+        state_(other.state_->copy())
+    {}
+
+    any(any&& other) {
+        std::swap(other.state_, state_);
+    }
+
+    // any uses value semantics
+    template <
+        typename T,
+        typename = typename
+            util::enable_if_t<!std::is_same<util::decay_t<T>, any>::value>
+    >
+    any(T&& other):
+        state_(new model<util::decay_t<T>>(std::forward<T>(other)))
+    {}
+
+    bool has_value() const {
+        return (bool)state_;
+    }
+
+    const std::type_info& type() const {
+        return state_->type();
+    }
+
+private:
+
+    struct concept {
+        virtual ~concept() = default;
+
+        // TODO: comments
+        virtual const std::type_info& type() = 0;
+        virtual concept* copy() = 0;
+        //virtual void swap(concept& other) = 0;
+        //void(*move)(storage_union& src, storage_union& dest) noexcept;
+    };
+
+    template <typename T>
+    struct model: public concept {
+        ~model() = default;
+
+        concept* copy() override {
+            return new model<T>(*this);
+        }
+
+        const std::type_info& type() override {
+            return typeid(T);
+        }
+
+        model(const T& other):
+            value(other)
+        {}
+
+        model(T&& other):
+            value(std::move(other))
+        {}
+
+        T value;
+    };
+
+    std::unique_ptr<concept> state_;
+};
+
+template<class T>
+T any_cast(const any& operand) {
+
+}
+
+/*
+template<class T>
+T any_cast(any& operand);
+
+template<class T>
+T any_cast(any&& operand);
+
+template<class T>
+const T* any_cast(const any* operand);
+
+template<class T>
+T* any_cast(any* operand);
+*/
+
+} // namespace util
+} // namespace mc
+} // namespace nest

--- a/src/util/any.hpp
+++ b/src/util/any.hpp
@@ -103,26 +103,13 @@ private:
     template <typename T>
     struct model: public interface {
         ~model() = default;
-
         model(const T& other): value(other) {}
-
         model(T&& other): value(std::move(other)) {}
 
-        interface* copy() override {
-            return new model<T>(*this);
-        }
-
-        const std::type_info& type() override {
-            return typeid(T);
-        }
-
-        void* pointer() override {
-            return &value;
-        }
-
-        const void* pointer() const override {
-            return &value;
-        }
+        interface* copy() override { return new model<T>(*this); }
+        const std::type_info& type() override { return typeid(T); }
+        void* pointer() override { return &value; }
+        const void* pointer() const override { return &value; }
 
         T value;
     };
@@ -130,7 +117,6 @@ private:
     std::unique_ptr<interface> state_;
 
 protected:
-
     template <typename T>
     friend const T* any_cast(const any* operand);
 

--- a/src/util/any.hpp
+++ b/src/util/any.hpp
@@ -15,9 +15,9 @@
 //
 // - Does not avoid dynamic allocation of small objects.
 // - Does not implement the in_place_type<T> constructors from the standard.
-// - Does not implement the in_place_type<T> constructors from the standard.
+// - Does not implement the emplace modifier from the standard.
+// - Does not implement the make_any non-member function from the standard.
 //
-
 
 namespace nest {
 namespace mc {
@@ -50,8 +50,7 @@ public:
         typename = typename
             util::enable_if_t<!std::is_same<util::decay_t<T>, any>::value>
     >
-    any(T&& other)
-    {
+    any(T&& other) {
         using contained_type = util::decay_t<T>;
         static_assert(
             std::is_copy_constructible<contained_type>::value,

--- a/src/util/any.hpp
+++ b/src/util/any.hpp
@@ -37,9 +37,7 @@ class any {
 public:
     constexpr any() = default;
 
-    any(const any& other):
-        state_(other.state_->copy())
-    {}
+    any(const any& other): state_(other.state_->copy()) {}
 
     any(any&& other) noexcept {
         std::swap(other.state_, state_);
@@ -47,13 +45,11 @@ public:
 
     template <
         typename T,
-        typename = typename
-            util::enable_if_t<!std::is_same<util::decay_t<T>, any>::value>
+        typename = typename util::enable_if_t<!std::is_same<util::decay_t<T>, any>::value>
     >
     any(T&& other) {
         using contained_type = util::decay_t<T>;
-        static_assert(
-            std::is_copy_constructible<contained_type>::value,
+        static_assert(std::is_copy_constructible<contained_type>::value,
             "Type of contained object stored in any must satisfy the CopyConstructible requirements.");
 
         state_.reset(new model<contained_type>(std::forward<T>(other)));
@@ -71,14 +67,12 @@ public:
 
     template <
         typename T,
-        typename = typename
-            util::enable_if_t<!std::is_same<util::decay_t<T>, any>::value>
+        typename = typename util::enable_if_t<!std::is_same<util::decay_t<T>, any>::value>
     >
     any& operator=(T&& other) {
         using contained_type = util::decay_t<T>;
 
-        static_assert(
-            std::is_copy_constructible<contained_type>::value,
+        static_assert(std::is_copy_constructible<contained_type>::value,
             "Type of contained object stored in any must satisfy the CopyConstructible requirements.");
 
         state_.reset(new model<contained_type>(std::forward<T>(other)));
@@ -98,11 +92,10 @@ public:
     }
 
     const std::type_info& type() const noexcept {
-        return state_->type();
+        return has_value()? state_->type(): typeid(void);
     }
 
 private:
-
     struct interface {
         virtual ~interface() = default;
         virtual const std::type_info& type() = 0;
@@ -115,6 +108,10 @@ private:
     struct model: public interface {
         ~model() = default;
 
+        model(const T& other): value(other) {}
+
+        model(T&& other): value(std::move(other)) {}
+
         interface* copy() override {
             return new model<T>(*this);
         }
@@ -123,19 +120,11 @@ private:
             return typeid(T);
         }
 
-        model(const T& other):
-            value(other)
-        {}
-
-        model(T&& other):
-            value(std::move(other))
-        {}
-
-        void* pointer() {
+        void* pointer() override {
             return &value;
         }
 
-        const void* pointer() const {
+        const void* pointer() const override {
             return &value;
         }
 
@@ -154,38 +143,21 @@ protected:
 
     template <typename T>
     T* unsafe_cast() {
-        return reinterpret_cast<T*>(state_->pointer());
+        return static_cast<T*>(state_->pointer());
     }
 
     template <typename T>
     const T* unsafe_cast() const {
-        return reinterpret_cast<T*>(state_->pointer());
+        return static_cast<const T*>(state_->pointer());
     }
 };
 
 namespace impl {
-    template <typename T>
-    using any_cast_remove_qual = typename
-        std::remove_cv<typename std::remove_reference<T>::type>::type;
 
-    template <typename ValueType, typename U=any_cast_remove_qual<ValueType>>
-    using test_any_cast_constructable = typename
-        std::conditional<
-               std::is_constructible<ValueType, const U&>::value
-            && std::is_constructible<ValueType, U&>::value
-            && std::is_constructible<ValueType, U>::value,
-            std::true_type,
-            std::false_type>::type;
+template <typename T>
+using any_cast_remove_qual = typename
+    std::remove_cv<typename std::remove_reference<T>::type>::type;
 
-    template<typename T>
-    inline T move_else_copy(any_cast_remove_qual<T>* p, std::true_type) {
-        return std::move(*p);
-    }
-
-    template<typename T>
-    inline T move_else_copy(any_cast_remove_qual<T>* p, std::false_type) {
-        return *p;
-    }
 } // namespace impl
 
 // If operand is not a null pointer, and the typeid of the requested T matches
@@ -193,44 +165,26 @@ namespace impl {
 // otherwise a null pointer.
 template<class T>
 const T* any_cast(const any* operand) {
-    static_assert(
-        impl::test_any_cast_constructable<T>::value,
-        "any_cast requires ");
-
-    if (operand==nullptr || !operand->has_value()) {
-        return nullptr;
+    if (operand && operand->type()==typeid(T)) {
+        return operand->unsafe_cast<T>();
     }
-
-    if (operand->type() != typeid(T)) {
-        throw bad_any_cast();
-    }
-
-    return operand->unsafe_cast<T>();
+    return nullptr;
 }
 
-// If operand is not a null pointer, and the typeid of the requested T matches
-// that of the contents of operand, a pointer to the value contained by operand,
-// otherwise a null pointer.
 template<class T>
 T* any_cast(any* operand) {
-    static_assert(
-        impl::test_any_cast_constructable<T>::value,
-        "any_cast can't construct the desired type");
-
-    if (operand==nullptr || !operand->has_value()) {
-        return nullptr;
+    if (operand && operand->type()==typeid(T)) {
+        return operand->unsafe_cast<T>();
     }
-
-    if (operand->type() != typeid(T)) {
-        throw bad_any_cast();
-    }
-
-    return operand->unsafe_cast<T>();
+    return nullptr;
 }
 
 template<class T>
 T any_cast(const any& operand) {
     using U = impl::any_cast_remove_qual<T>;
+    static_assert(std::is_constructible<T, const U&>::value,
+        "any_cast type can't construct copy of contained object");
+
     auto ptr = any_cast<U>(&operand);
     if (ptr==nullptr) {
         throw bad_any_cast();
@@ -241,6 +195,9 @@ T any_cast(const any& operand) {
 template<class T>
 T any_cast(any& operand) {
     using U = impl::any_cast_remove_qual<T>;
+    static_assert(std::is_constructible<T, U&>::value,
+        "any_cast type can't construct copy of contained object");
+
     auto ptr = any_cast<U>(&operand);
     if (ptr==nullptr) {
         throw bad_any_cast();
@@ -251,17 +208,14 @@ T any_cast(any& operand) {
 template<class T>
 T any_cast(any&& operand) {
     using U = impl::any_cast_remove_qual<T>;
-    using do_move = typename
-        std::conditional<
-            std::is_move_constructible<T>::value
-            & !std::is_lvalue_reference<T>::value,
-            std::true_type, std::false_type>::type;
+    static_assert(std::is_constructible<T, U>::value,
+        "any_cast type can't construct copy of contained object");
 
     auto ptr = any_cast<U>(&operand);
     if (ptr==nullptr) {
         throw bad_any_cast();
     }
-    return impl::move_else_copy<T>(static_cast<T*>(ptr), do_move());
+    return static_cast<T>(std::move(*ptr));
 }
 
 } // namespace util

--- a/src/util/any.hpp
+++ b/src/util/any.hpp
@@ -4,6 +4,8 @@
 #include <typeinfo>
 #include <type_traits>
 
+#include <iostream> // TODO: remove
+
 #include <util/meta.hpp>
 
 // Partial implementation of std::any from C++17 standard.
@@ -11,12 +13,25 @@
 //
 // Implements a standard-compliant subset of the full interface.
 //
-// Does not attempt to avoid dynamic allocation of small objects.
+// - Does not avoid dynamic allocation of small objects.
+// - Does not implement the in_place_type<T> constructors from the standard.
+// - Does not implement the in_place_type<T> constructors from the standard.
+//
 
 
 namespace nest {
 namespace mc {
 namespace util {
+
+// Defines a type of object to be thrown by the value-returning forms of
+// util::any_cast on failure.
+//      http://en.cppreference.com/w/cpp/utility/any/bad_any_cast
+class bad_any_cast: public std::bad_cast {
+public:
+    const char* what() const noexcept override {
+        return "bad any cast";
+    }
+};
 
 class any {
 public:
@@ -26,45 +41,82 @@ public:
         state_(other.state_->copy())
     {}
 
-    any(any&& other) {
+    any(any&& other) noexcept {
         std::swap(other.state_, state_);
     }
 
-    // any uses value semantics
     template <
         typename T,
         typename = typename
             util::enable_if_t<!std::is_same<util::decay_t<T>, any>::value>
     >
-    any(T&& other):
-        state_(new model<util::decay_t<T>>(std::forward<T>(other)))
-    {}
+    any(T&& other)
+    {
+        using contained_type = util::decay_t<T>;
+        static_assert(
+            std::is_copy_constructible<contained_type>::value,
+            "Type of contained object stored in any must satisfy the CopyConstructible requirements.");
 
-    bool has_value() const {
+        state_.reset(new model<contained_type>(std::forward<T>(other)));
+    }
+
+    any& operator=(const any& other) {
+        state_.reset(other.state_->copy());
+        return *this;
+    }
+
+    any& operator=(any&& other) noexcept {
+        swap(other);
+        return *this;
+    }
+
+    template <
+        typename T,
+        typename = typename
+            util::enable_if_t<!std::is_same<util::decay_t<T>, any>::value>
+    >
+    any& operator=(T&& other) {
+        using contained_type = util::decay_t<T>;
+
+        static_assert(
+            std::is_copy_constructible<contained_type>::value,
+            "Type of contained object stored in any must satisfy the CopyConstructible requirements.");
+
+        state_.reset(new model<contained_type>(std::forward<T>(other)));
+        return *this;
+    }
+
+    void reset() noexcept {
+        state_.reset(nullptr);
+    }
+
+    void swap(any& other) noexcept {
+        std::swap(other.state_, state_);
+    }
+
+    bool has_value() const noexcept {
         return (bool)state_;
     }
 
-    const std::type_info& type() const {
+    const std::type_info& type() const noexcept {
         return state_->type();
     }
 
 private:
 
-    struct concept {
-        virtual ~concept() = default;
-
-        // TODO: comments
+    struct interface {
+        virtual ~interface() = default;
         virtual const std::type_info& type() = 0;
-        virtual concept* copy() = 0;
-        //virtual void swap(concept& other) = 0;
-        //void(*move)(storage_union& src, storage_union& dest) noexcept;
+        virtual interface* copy() = 0;
+        virtual void* pointer() = 0;
+        virtual const void* pointer() const = 0;
     };
 
     template <typename T>
-    struct model: public concept {
+    struct model: public interface {
         ~model() = default;
 
-        concept* copy() override {
+        interface* copy() override {
             return new model<T>(*this);
         }
 
@@ -80,30 +132,138 @@ private:
             value(std::move(other))
         {}
 
+        void* pointer() {
+            return &value;
+        }
+
+        const void* pointer() const {
+            return &value;
+        }
+
         T value;
     };
 
-    std::unique_ptr<concept> state_;
+    std::unique_ptr<interface> state_;
+
+protected:
+
+    template <typename T>
+    friend const T* any_cast(const any* operand);
+
+    template <typename T>
+    friend T* any_cast(any* operand);
+
+    template <typename T>
+    T* unsafe_cast() {
+        return reinterpret_cast<T*>(state_->pointer());
+    }
+
+    template <typename T>
+    const T* unsafe_cast() const {
+        return reinterpret_cast<T*>(state_->pointer());
+    }
 };
+
+namespace impl {
+    template <typename T>
+    using any_cast_remove_qual = typename
+        std::remove_cv<typename std::remove_reference<T>::type>::type;
+
+    template <typename ValueType, typename U=any_cast_remove_qual<ValueType>>
+    using test_any_cast_constructable = typename
+        std::conditional<
+               std::is_constructible<ValueType, const U&>::value
+            && std::is_constructible<ValueType, U&>::value
+            && std::is_constructible<ValueType, U>::value,
+            std::true_type,
+            std::false_type>::type;
+
+    template<typename T>
+    inline T move_else_copy(any_cast_remove_qual<T>* p, std::true_type) {
+        return std::move(*p);
+    }
+
+    template<typename T>
+    inline T move_else_copy(any_cast_remove_qual<T>* p, std::false_type) {
+        return *p;
+    }
+} // namespace impl
+
+// If operand is not a null pointer, and the typeid of the requested T matches
+// that of the contents of operand, a pointer to the value contained by operand,
+// otherwise a null pointer.
+template<class T>
+const T* any_cast(const any* operand) {
+    static_assert(
+        impl::test_any_cast_constructable<T>::value,
+        "any_cast requires ");
+
+    if (operand==nullptr || !operand->has_value()) {
+        return nullptr;
+    }
+
+    if (operand->type() != typeid(T)) {
+        throw bad_any_cast();
+    }
+
+    return operand->unsafe_cast<T>();
+}
+
+// If operand is not a null pointer, and the typeid of the requested T matches
+// that of the contents of operand, a pointer to the value contained by operand,
+// otherwise a null pointer.
+template<class T>
+T* any_cast(any* operand) {
+    static_assert(
+        impl::test_any_cast_constructable<T>::value,
+        "any_cast can't construct the desired type");
+
+    if (operand==nullptr || !operand->has_value()) {
+        return nullptr;
+    }
+
+    if (operand->type() != typeid(T)) {
+        throw bad_any_cast();
+    }
+
+    return operand->unsafe_cast<T>();
+}
 
 template<class T>
 T any_cast(const any& operand) {
-
+    using U = impl::any_cast_remove_qual<T>;
+    auto ptr = any_cast<U>(&operand);
+    if (ptr==nullptr) {
+        throw bad_any_cast();
+    }
+    return static_cast<T>(*ptr);
 }
 
-/*
 template<class T>
-T any_cast(any& operand);
+T any_cast(any& operand) {
+    using U = impl::any_cast_remove_qual<T>;
+    auto ptr = any_cast<U>(&operand);
+    if (ptr==nullptr) {
+        throw bad_any_cast();
+    }
+    return static_cast<T>(*ptr);
+}
 
 template<class T>
-T any_cast(any&& operand);
+T any_cast(any&& operand) {
+    using U = impl::any_cast_remove_qual<T>;
+    using do_move = typename
+        std::conditional<
+            std::is_move_constructible<T>::value
+            & !std::is_lvalue_reference<T>::value,
+            std::true_type, std::false_type>::type;
 
-template<class T>
-const T* any_cast(const any* operand);
-
-template<class T>
-T* any_cast(any* operand);
-*/
+    auto ptr = any_cast<U>(&operand);
+    if (ptr==nullptr) {
+        throw bad_any_cast();
+    }
+    return impl::move_else_copy<T>(static_cast<T*>(ptr), do_move());
+}
 
 } // namespace util
 } // namespace mc

--- a/src/util/any.hpp
+++ b/src/util/any.hpp
@@ -218,6 +218,13 @@ T any_cast(any&& operand) {
     return static_cast<T>(std::move(*ptr));
 }
 
+// Constructs an any object containing an object of type T, passing the
+// provided arguments to T's constructor.
+template <class T, class... Args>
+any make_any(Args&&... args) {
+    return any(T(std::forward<Args>(args) ...));
+}
+
 } // namespace util
 } // namespace mc
 } // namespace nest

--- a/src/util/unique_any.hpp
+++ b/src/util/unique_any.hpp
@@ -1,0 +1,197 @@
+#pragma once
+
+#include <memory>
+#include <typeinfo>
+#include <type_traits>
+
+#include <util/any.hpp>
+#include <util/meta.hpp>
+
+// A version of util::any that is not copyable.
+// The two main use cases for such a container are
+//  1. for storing types that are not copyable.
+//  2. for ensuring that no copies are made of types that are copyable.
+//     e.g. in performance critical code.
+
+namespace nest {
+namespace mc {
+namespace util {
+
+class unique_any {
+public:
+    constexpr unique_any() = default;
+
+    unique_any(unique_any&& other) noexcept {
+        std::swap(other.state_, state_);
+    }
+
+    template <
+        typename T,
+        typename = typename util::enable_if_t<!std::is_same<util::decay_t<T>, unique_any>::value>
+    >
+    unique_any(T&& other) {
+        using contained_type = util::decay_t<T>;
+        state_.reset(new model<contained_type>(std::forward<T>(other)));
+    }
+
+    unique_any& operator=(unique_any&& other) noexcept {
+        swap(other);
+        return *this;
+    }
+
+    template <
+        typename T,
+        typename = typename util::enable_if_t<!std::is_same<util::decay_t<T>, unique_any>::value>
+    >
+    unique_any& operator=(T&& other) {
+        using contained_type = util::decay_t<T>;
+        state_.reset(new model<contained_type>(std::forward<T>(other)));
+        return *this;
+    }
+
+    void reset() noexcept {
+        state_.reset(nullptr);
+    }
+
+    void swap(unique_any& other) noexcept {
+        std::swap(other.state_, state_);
+    }
+
+    bool has_value() const noexcept {
+        return (bool)state_;
+    }
+
+    const std::type_info& type() const noexcept {
+        return has_value()? state_->type(): typeid(void);
+    }
+
+private:
+    struct interface {
+        virtual ~interface() = default;
+        virtual const std::type_info& type() = 0;
+        virtual void* pointer() = 0;
+        virtual const void* pointer() const = 0;
+    };
+
+    template <typename T>
+    struct model: public interface {
+        ~model() = default;
+
+        model(const T& other): value(other) {}
+
+        model(T&& other): value(std::move(other)) {}
+
+        const std::type_info& type() override {
+            return typeid(T);
+        }
+
+        void* pointer() override {
+            return &value;
+        }
+
+        const void* pointer() const override {
+            return &value;
+        }
+
+        T value;
+    };
+
+    std::unique_ptr<interface> state_;
+
+protected:
+
+    template <typename T>
+    friend const T* any_cast(const unique_any* operand);
+
+    template <typename T>
+    friend T* any_cast(unique_any* operand);
+
+    template <typename T>
+    T* unsafe_cast() {
+        return static_cast<T*>(state_->pointer());
+    }
+
+    template <typename T>
+    const T* unsafe_cast() const {
+        return static_cast<const T*>(state_->pointer());
+    }
+};
+
+// If operand is not a null pointer, and the typeid of the requested T matches
+// that of the contents of operand, a pointer to the value contained by operand,
+// otherwise a null pointer.
+template<class T>
+const T* any_cast(const unique_any* operand) {
+    if (operand && operand->type()==typeid(T)) {
+        return operand->unsafe_cast<T>();
+    }
+    return nullptr;
+}
+
+// If operand is not a null pointer, and the typeid of the requested T matches
+// that of the contents of operand, a pointer to the value contained by operand,
+// otherwise a null pointer.
+template<class T>
+T* any_cast(unique_any* operand) {
+    if (operand && operand->type()==typeid(T)) {
+        return operand->unsafe_cast<T>();
+    }
+    return nullptr;
+}
+
+// The semantics of any_cast for unique_any differ from any, because 
+// any_cast(any& / const any&/ any&&) return a copy of the contained object
+// in the argument to any_cast, while unique_any is designed to work with
+// non-copyable types.
+// Hence, references to the contained objects are returned, not copies.
+
+template<class T>
+T any_cast(const unique_any& operand) {
+    using U = impl::any_cast_remove_qual<T>;
+    static_assert(std::is_constructible<T, const U&>::value,
+        "any_cast type can't construct copy of contained object");
+
+    auto ptr = any_cast<U>(&operand);
+    if (ptr==nullptr) {
+        throw bad_any_cast();
+    }
+    return static_cast<T>(*ptr);
+}
+
+template<class T>
+T any_cast(unique_any& operand) {
+    using U = impl::any_cast_remove_qual<T>;
+    static_assert(std::is_constructible<T, U&>::value,
+        "any_cast type can't construct copy of contained object");
+
+    auto ptr = any_cast<U>(&operand);
+    if (ptr==nullptr) {
+        throw bad_any_cast();
+    }
+    return static_cast<T>(*ptr);
+}
+
+template<class T>
+T any_cast(unique_any&& operand) {
+    using U = impl::any_cast_remove_qual<T>;
+
+    static_assert(std::is_constructible<T, U&&>::value,
+        "any_cast type can't construct copy of contained object");
+
+    auto ptr = any_cast<U>(&operand);
+    if (ptr==nullptr) {
+        throw bad_any_cast();
+    }
+    return static_cast<T>(std::move(*ptr));
+}
+
+// Constructs an any object containing an object of type T, passing the
+// provided arguments to T's constructor.
+template <class T, class... Args>
+unique_any make_unique_any(Args&&... args) {
+    return unique_any(T(std::forward<Args>(args) ...));
+}
+
+} // namespace util
+} // namespace mc
+} // namespace nest

--- a/tests/global_communication/test_domain_decomposition.cpp
+++ b/tests/global_communication/test_domain_decomposition.cpp
@@ -13,15 +13,15 @@ using namespace nest::mc;
 
 using communicator_type = communication::communicator<communication::global_policy>;
 
-static bool is_dry_run() {
+inline bool is_dry_run() {
     return communication::global_policy::kind() ==
         communication::global_policy_kind::dryrun;
 }
 
 TEST(domain_decomp, basic) {
+/*
     using policy = communication::global_policy;
 
-/*
     const auto num_domains = policy::size();
     const auto rank = policy::id();
 */

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -69,6 +69,7 @@ set(TEST_SOURCES
     test_tree.cpp
     test_transform.cpp
     test_uninitialized.cpp
+    test_unique_any.cpp
     test_vector.cpp
 
     # unit test driver

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -31,6 +31,7 @@ set(TEST_CUDA_SOURCES
 set(TEST_SOURCES
     # unit tests
     test_algorithms.cpp
+    test_any.cpp
     test_backend.cpp
     test_double_buffer.cpp
     test_cell.cpp

--- a/tests/unit/test_any.cpp
+++ b/tests/unit/test_any.cpp
@@ -253,7 +253,57 @@ TEST(any, assignment_from_value) {
     // ensure the value was moved
     EXPECT_EQ(ptr, vec->data());
 
-    // ensure that the vector was copied correctly
+    // ensure that the contents of the vector are unchanged
     std::vector<int> ref{1, 2, 3};
     EXPECT_EQ(ref, *vec);
+}
+
+TEST(any, make_any) {
+    using util::make_any;
+    using util::any_cast;
+
+    {
+        auto a = make_any<int>(42);
+
+        EXPECT_EQ(typeid(int), a.type());
+        EXPECT_EQ(42, any_cast<int>(a));
+    }
+
+    // check casting
+    {
+        auto a = make_any<double>(42u);
+
+        EXPECT_EQ(typeid(double), a.type());
+        EXPECT_EQ(42.0, any_cast<double>(a));
+    }
+
+    // check forwarding of parameters to constructor
+    {
+        // create a string from const char*
+        auto a = make_any<std::string>("hello");
+
+        EXPECT_EQ(any_cast<std::string>(a), std::string("hello"));
+    }
+
+    // test that we make_any correctly forwards rvalue arguments to the constructor
+    // of the contained object.
+    {
+        std::vector<int> tmp{1, 2, 3};
+
+        // take a pointer to the orignal data to later verify
+        // that the value was moved, and not copied.
+        auto ptr = tmp.data();
+
+        auto a = make_any<std::vector<int>>(std::move(tmp));
+
+        auto vec = any_cast<std::vector<int>>(&a);
+
+        // ensure the value was moved
+        EXPECT_EQ(ptr, vec->data());
+
+        // ensure that the contents of the vector are unchanged
+        std::vector<int> ref{1, 2, 3};
+        EXPECT_EQ(ref, *vec);
+    }
+
 }

--- a/tests/unit/test_any.cpp
+++ b/tests/unit/test_any.cpp
@@ -1,0 +1,50 @@
+#include "../gtest.h"
+
+#include <iostream>
+
+#include <util/any.hpp>
+
+using namespace nest::mc;
+
+TEST(any, copy_construction) {
+    util::any any_int(2);
+    EXPECT_EQ(any_int.type(), typeid(int));
+
+    util::any any_float(2.0f);
+    EXPECT_EQ(any_float.type(), typeid(float));
+
+    std::string str = "hello";
+    util::any any_string(str);
+    EXPECT_EQ(any_string.type(), typeid(std::string));
+}
+
+namespace {
+
+    struct moveable {
+        moveable() = default;
+
+        moveable(moveable&& other) {
+            moves = other.moves+1;
+            std::cout << "move " << moves << "\n";
+        }
+
+        moveable(const moveable& other) {
+            copies = other.copies + 1;
+            std::cout << "copy " << copies << "\n";
+        }
+
+        int moves=0;
+        int copies=0;
+    };
+
+}
+
+TEST(any, move_construction) {
+    moveable m;
+
+    util::any copied(m);
+    util::any moved(std::move(m));
+
+    util::any x(copied);
+    util::any y(moved);
+}

--- a/tests/unit/test_any.cpp
+++ b/tests/unit/test_any.cpp
@@ -115,9 +115,6 @@ TEST(any, swap) {
     EXPECT_EQ(typeid(double), any2.type());
 }
 
-TEST(any, constness) {
-}
-
 // These should fail at compile time if the constraint that the contents of any
 // satisfy CopyConstructable. This implementation is rock solid, so they have
 // to be commented out.
@@ -168,10 +165,29 @@ TEST(any, any_cast_ptr) {
 }
 
 TEST(any, any_cast_ref) {
-    util::any ai(42);
-    auto i = util::any_cast<int>(ai);
-    EXPECT_EQ(typeid(i), typeid(int));
-    EXPECT_EQ(i, 42);
+    {
+        util::any a(42);
+        auto i = util::any_cast<int>(a);
+        EXPECT_EQ(typeid(i), typeid(int));
+        EXPECT_EQ(i, 42);
+
+        // check that we can take a reference to the
+        // underlying storage
+        auto& r = util::any_cast<int&>(a);
+        r = 3;
+        EXPECT_EQ(3, util::any_cast<int>(a));
+        EXPECT_TRUE((std::is_same<int&, decltype(r)>::value));
+    }
+
+    {   // check that const references can be returned to const objects
+        const util::any a(42);
+        auto& r = util::any_cast<const int&>(a);
+        EXPECT_TRUE((std::is_same<const int&, decltype(r)>::value));
+
+        // The following should fail with a static assertion if uncommented, because
+        // it requests a non-const reference to a const object.
+        //auto& instafail = util::any_cast<int&>(a);
+    }
 }
 
 // test any_cast(any&&)

--- a/tests/unit/test_any.cpp
+++ b/tests/unit/test_any.cpp
@@ -23,15 +23,13 @@ namespace {
     struct moveable {
         moveable() = default;
 
-        moveable(moveable&& other) {
-            moves = other.moves+1;
-            std::cout << "move " << moves << "\n";
-        }
+        moveable(moveable&& other):
+            moves(other.moves+1), copies(other.copies)
+        {}
 
-        moveable(const moveable& other) {
-            copies = other.copies + 1;
-            std::cout << "copy " << copies << "\n";
-        }
+        moveable(const moveable& other):
+            moves(other.moves), copies(other.copies+1)
+        {}
 
         int moves=0;
         int copies=0;
@@ -45,6 +43,165 @@ TEST(any, move_construction) {
     util::any copied(m);
     util::any moved(std::move(m));
 
-    util::any x(copied);
-    util::any y(moved);
+    // Check that the expected number of copies and moves were performed.
+    // Note that any_cast(any*) is used instead of any_cast(const any&) because
+    // any_cast(const any&) returns a copy.
+    const auto& cref = *util::any_cast<moveable>(&copied);
+    EXPECT_EQ(cref.moves, 0);
+    EXPECT_EQ(cref.copies, 1);
+
+    const auto& mref = *util::any_cast<moveable>(&moved);
+    EXPECT_EQ(mref.moves, 1);
+    EXPECT_EQ(mref.copies, 0);
+
+    // construction by any&& should not make any copies or moves of the
+    // constructed value
+    util::any fin(std::move(moved));
+    EXPECT_FALSE(moved.has_value()); // moved has been moved from and should be empty
+    const auto& fref = *util::any_cast<moveable>(&fin);
+    EXPECT_EQ(fref.moves, 1);
+    EXPECT_EQ(fref.copies, 0);
+
+    const auto value = util::any_cast<moveable>(fin);
+    EXPECT_EQ(value.moves, 1);
+    EXPECT_EQ(value.copies, 1);
+}
+
+TEST(any, swap) {
+    using util::any;
+    using util::any_cast;
+
+    any any1(42);     // integer
+    any any2(3.14);   // double
+
+    EXPECT_EQ(typeid(int),    any1.type());
+    EXPECT_EQ(typeid(double), any2.type());
+
+    any1.swap(any2);
+
+    EXPECT_EQ(any_cast<int>(any2), 42);
+    EXPECT_EQ(any_cast<double>(any1), 3.14);
+
+    EXPECT_EQ(typeid(double), any1.type());
+    EXPECT_EQ(typeid(int),    any2.type());
+
+    any1.swap(any2);
+
+    EXPECT_EQ(any_cast<double>(any2), 3.14);
+    EXPECT_EQ(any_cast<int>(any1), 42);
+
+    EXPECT_EQ(typeid(int),    any1.type());
+    EXPECT_EQ(typeid(double), any2.type());
+}
+
+// test any_cast(any*)
+//   - these have different behavior to any_cast on reference types
+//   - are used by the any_cast on refernce types
+TEST(any, any_cast_ptr) {
+
+    // test that valid pointers are returned for int and std::string types
+
+    util::any ai(42);
+    auto ptr_i = util::any_cast<int>(&ai);
+    EXPECT_EQ(*ptr_i, 42);
+
+    util::any as(std::string("hello"));
+    auto ptr_s = util::any_cast<std::string>(&as);
+    EXPECT_EQ(*ptr_s, "hello");
+
+    // test that exceptions are thrown for invalid casts
+    EXPECT_THROW(util::any_cast<int>(&as), util::bad_any_cast);
+    EXPECT_THROW(util::any_cast<std::string>(&ai), util::bad_any_cast);
+    util::any empty;
+    EXPECT_EQ(util::any_cast<int>(&empty), nullptr);
+}
+
+TEST(any, any_cast_ref) {
+    util::any ai(42);
+    auto i = util::any_cast<int>(ai);
+    EXPECT_EQ(typeid(i), typeid(int));
+    EXPECT_EQ(i, 42);
+}
+
+// test any_cast(any&&)
+TEST(any, any_cast_rvalue) {
+    auto moved = util::any_cast<moveable>(util::any(moveable()));
+    std::cout << "moves and copies: " << moved.moves << " " << moved.copies  << "\n";
+}
+
+TEST(any, std_swap) {
+    util::any a1(42);
+    util::any a2(3.14);
+
+    auto pi = util::any_cast<int>(&a1);
+    auto pd = util::any_cast<double>(&a2);
+
+    std::swap(a1, a2);
+
+    // test that values were swapped
+    EXPECT_EQ(util::any_cast<int>(a2), 42);
+    EXPECT_EQ(util::any_cast<double>(a1), 3.14);
+
+    // test that underlying pointers did not change
+    EXPECT_EQ(pi, util::any_cast<int>(&a2));
+    EXPECT_EQ(pd, util::any_cast<double>(&a1));
+}
+
+// test operator=(const any&)
+TEST(any, assignment_from_lvalue) {
+    using std::string;
+
+    auto str1 = string("one");
+    auto str2 = string("two");
+    util::any a(str1);
+
+    util::any b;
+    b = a; // copy assignment
+
+    // verify that b contains value stored in a
+    EXPECT_EQ(str1, util::any_cast<string>(b));
+
+    // change the value stored in b
+    *util::any_cast<string>(&b) = str2;
+
+    // verify that a is unchanged and that b holds new value
+    EXPECT_EQ(str1, util::any_cast<string>(a));
+    EXPECT_EQ(str2, util::any_cast<string>(b));
+}
+
+// test operator=(any&&)
+TEST(any, assignment_from_rvalue) {
+    using std::string;
+
+    auto str1 = string("one");
+    auto str2 = string("two");
+    util::any a(str1);
+
+    util::any b;
+    b = std::move(a); // move assignment
+
+    EXPECT_EQ(str1, util::any_cast<string>(b));
+
+    EXPECT_EQ(nullptr, util::any_cast<string>(&a));
+}
+
+// test template<typename T> operator=(T&&)
+TEST(any, assignment_from_value) {
+    std::vector<int> tmp{1, 2, 3};
+
+    // take a pointer to the orignal data to later verify
+    // that the value was moved, and not copied.
+    auto ptr = tmp.data();
+
+    util::any a;
+    a = std::move(tmp);
+
+    auto vec = util::any_cast<std::vector<int>>(&a);
+
+    // ensure the value was moved
+    EXPECT_EQ(ptr, vec->data());
+
+    // ensure that the vector was copied correctly
+    std::vector<int> ref{1, 2, 3};
+    EXPECT_EQ(ref, *vec);
 }

--- a/tests/unit/test_unique_any.cpp
+++ b/tests/unit/test_unique_any.cpp
@@ -1,0 +1,319 @@
+#include "../gtest.h"
+#include "common.hpp"
+
+#include <iostream>
+
+#include <util/unique_any.hpp>
+
+using namespace nest::mc;
+
+TEST(unique_any, copy_construction) {
+    using util::unique_any;
+
+    unique_any any_int(2);
+    EXPECT_EQ(any_int.type(), typeid(int));
+
+    unique_any any_float(2.0f);
+    EXPECT_EQ(any_float.type(), typeid(float));
+
+    std::string str = "hello";
+    unique_any any_string(str);
+    EXPECT_EQ(any_string.type(), typeid(std::string));
+}
+
+namespace {
+
+    struct moveable {
+        moveable() = default;
+
+        moveable(moveable&& other):
+            moves(other.moves+1), copies(other.copies)
+        {}
+
+        moveable(const moveable& other):
+            moves(other.moves), copies(other.copies+1)
+        {}
+
+        int moves=0;
+        int copies=0;
+    };
+
+}
+
+TEST(unique_any, move_construction) {
+    moveable m;
+
+    util::unique_any copied(m);
+    util::unique_any moved(std::move(m));
+
+    // Check that the expected number of copies and moves were performed.
+    // Note that any_cast(any*) is used instead of any_cast(const any&) because
+    // any_cast(const any&) returns a copy.
+    const auto& cref = util::any_cast<const moveable&>(copied);
+    EXPECT_EQ(cref.moves, 0);
+    EXPECT_EQ(cref.copies, 1);
+
+    const auto& mref = util::any_cast<const moveable&>(moved);
+    EXPECT_EQ(mref.moves, 1);
+    EXPECT_EQ(mref.copies, 0);
+
+    // construction by any&& should not make any copies or moves of the
+    // constructed value
+    util::unique_any fin(std::move(moved));
+    EXPECT_FALSE(moved.has_value()); // moved has been moved from and should be empty
+    const auto& fref = util::any_cast<const moveable&>(fin);
+    EXPECT_EQ(fref.moves, 1);
+    EXPECT_EQ(fref.copies, 0);
+
+    const auto value = util::any_cast<moveable>(fin);
+    EXPECT_EQ(value.moves, 1);
+    EXPECT_EQ(value.copies, 1);
+}
+
+TEST(unique_any, type) {
+    using util::unique_any;
+
+    unique_any anyi(42);
+    unique_any anys(std::string("hello"));
+    unique_any anyv(std::vector<int>{1, 2, 3});
+    unique_any any0;
+
+    EXPECT_EQ(typeid(int), anyi.type());
+    EXPECT_EQ(typeid(std::string), anys.type());
+    EXPECT_EQ(typeid(std::vector<int>), anyv.type());
+    EXPECT_EQ(typeid(void), any0.type());
+
+    anyi.reset();
+    EXPECT_EQ(typeid(void), anyi.type());
+
+    anyi = std::true_type();
+    EXPECT_EQ(typeid(std::true_type), anyi.type());
+}
+
+TEST(unique_any, swap) {
+    using util::unique_any;
+    using util::any_cast;
+
+    unique_any any1(42);     // integer
+    unique_any any2(3.14);   // double
+
+    EXPECT_EQ(typeid(int),    any1.type());
+    EXPECT_EQ(typeid(double), any2.type());
+
+    any1.swap(any2);
+
+    EXPECT_EQ(any_cast<int>(any2), 42);
+    EXPECT_EQ(any_cast<double>(any1), 3.14);
+
+    EXPECT_EQ(typeid(double), any1.type());
+    EXPECT_EQ(typeid(int),    any2.type());
+
+    any1.swap(any2);
+
+    EXPECT_EQ(any_cast<double>(any2), 3.14);
+    EXPECT_EQ(any_cast<int>(any1), 42);
+
+    EXPECT_EQ(typeid(int),    any1.type());
+    EXPECT_EQ(typeid(double), any2.type());
+}
+
+TEST(unique_any, not_copy_constructable) {
+    using T = testing::nocopy<int>;
+
+    util::unique_any a(T(42));
+
+    auto& ref = util::any_cast<T&>(a);
+    EXPECT_EQ(ref, 42);
+    ref.value = 100;
+
+    EXPECT_EQ(util::any_cast<T&>(a).value, 100);
+
+    // the following will fail if uncommented, because we are requesting
+    // a copy of an non-copyable type.
+
+    //auto value = util::any_cast<T>(a);
+
+    // Test that we can move the contents of the unique_any.
+    // NOTE: it makes sense to sink a with std::move(a) instead
+    // of the following, because after such an assignment a will
+    // be in a moved from state, and enforcing std::move(a) it
+    // is made clearer in the calling code that a has been invalidated.
+    //     util::any_cast<T&&>(a)
+    T val(util::any_cast<T&&>(std::move(a)));
+    EXPECT_EQ(val.value, 100);
+}
+
+// test any_cast(unique_any*) and any_cast(const unique_any*)
+//   - these have different behavior to any_cast on reference types
+//   - are used by the any_cast on refernce types
+TEST(unique_any, any_cast_ptr) {
+    using util::unique_any;
+
+    // test that valid pointers are returned for int and std::string types
+
+    unique_any ai(42);
+    auto ptr_i = util::any_cast<int>(&ai);
+    EXPECT_EQ(*ptr_i, 42);
+
+    unique_any as(std::string("hello"));
+    auto ptr_s = util::any_cast<std::string>(&as);
+    EXPECT_EQ(*ptr_s, "hello");
+
+    // test that exceptions are thrown for invalid casts
+    EXPECT_EQ(util::any_cast<int>(&as), nullptr);
+    EXPECT_EQ(util::any_cast<std::string>(&ai), nullptr);
+    unique_any empty;
+    EXPECT_EQ(util::any_cast<int>(&empty), nullptr);
+    EXPECT_EQ(util::any_cast<int>((util::unique_any*)nullptr), nullptr);
+
+    // Check that constness of the returned pointer matches that the input.
+    {
+        unique_any a(42);
+        auto p = util::any_cast<int>(&a);
+        static_assert(std::is_same<int*, decltype(p)>::value,
+                "any_cast(any*) should not return const*");
+    }
+    {
+        const unique_any a(42);
+        auto p = util::any_cast<int>(&a);
+        static_assert(std::is_same<const int*, decltype(p)>::value,
+                "any_cast(const any*) should return const*");
+    }
+}
+
+// test any_cast(unique_any&)
+TEST(unique_any, any_cast_ref) {
+    util::unique_any ai(42);
+    auto& i = util::any_cast<int&>(ai);
+
+    EXPECT_EQ(typeid(i), typeid(int));
+    EXPECT_EQ(i, 42);
+
+    // any_cast<T>(unique_any&) returns a 
+    i = 100;
+    EXPECT_EQ(util::any_cast<int>(ai), 100);
+}
+
+// test any_cast(const unique_any&)
+TEST(unique_any, any_cast_const_ref) {
+    const util::unique_any ai(42);
+    auto& i = util::any_cast<const int&>(ai);
+
+    EXPECT_EQ(typeid(i), typeid(int));
+    EXPECT_EQ(i, 42);
+
+    EXPECT_TRUE((std::is_same<const int&, decltype(i)>::value));
+}
+
+// test any_cast(any&&)
+TEST(unique_any, any_cast_rvalue) {
+    auto moved = util::any_cast<moveable>(util::unique_any(moveable()));
+    EXPECT_EQ(moved.moves, 2);
+    EXPECT_EQ(moved.copies, 0);
+}
+
+TEST(unique_any, std_swap) {
+    util::unique_any a1(42);
+    util::unique_any a2(3.14);
+
+    auto pi = util::any_cast<int>(&a1);
+    auto pd = util::any_cast<double>(&a2);
+
+    std::swap(a1, a2);
+
+    // test that values were swapped
+    EXPECT_EQ(util::any_cast<int>(a2), 42);
+    EXPECT_EQ(util::any_cast<double>(a1), 3.14);
+
+    // test that underlying pointers did not change
+    EXPECT_EQ(pi, util::any_cast<int>(&a2));
+    EXPECT_EQ(pd, util::any_cast<double>(&a1));
+}
+
+// test operator=(any&&)
+TEST(unique_any, assignment_from_rvalue) {
+    using util::unique_any;
+    using std::string;
+
+    auto str1 = string("one");
+    auto str2 = string("two");
+    unique_any a(str1);
+
+    unique_any b;
+    b = std::move(a); // move assignment
+
+    EXPECT_EQ(str1, util::any_cast<string>(b));
+
+    EXPECT_EQ(nullptr, util::any_cast<string>(&a));
+}
+
+// test template<typename T> operator=(T&&)
+TEST(unique_any, assignment_from_value) {
+    using util::unique_any;
+    std::vector<int> tmp{1, 2, 3};
+
+    // take a pointer to the orignal data to later verify
+    // that the value was moved, and not copied.
+    auto ptr = tmp.data();
+
+    unique_any a;
+    a = std::move(tmp);
+
+    auto vec = util::any_cast<std::vector<int>>(&a);
+
+    // ensure the value was moved
+    EXPECT_EQ(ptr, vec->data());
+
+    // ensure that the contents of the vector are unchanged
+    std::vector<int> ref{1, 2, 3};
+    EXPECT_EQ(ref, *vec);
+}
+
+TEST(unique_any, make_unique_any) {
+    using util::make_unique_any;
+    using util::any_cast;
+
+    {
+        auto a = make_unique_any<int>(42);
+
+        EXPECT_EQ(typeid(int), a.type());
+        EXPECT_EQ(42, any_cast<int>(a));
+    }
+
+    // check casting
+    {
+        auto a = make_unique_any<double>(42u);
+
+        EXPECT_EQ(typeid(double), a.type());
+        EXPECT_EQ(42.0, any_cast<double>(a));
+    }
+
+    // check forwarding of parameters to constructor
+    {
+        // create a string from const char*
+        auto a = make_unique_any<std::string>("hello");
+
+        EXPECT_EQ(any_cast<std::string>(a), std::string("hello"));
+    }
+
+    // test that we make_unique_any correctly forwards rvalue arguments to the constructor
+    // of the contained object.
+    {
+        std::vector<int> tmp{1, 2, 3};
+
+        // take a pointer to the orignal data to later verify
+        // that the value was moved, and not copied.
+        auto ptr = tmp.data();
+
+        auto a = make_unique_any<std::vector<int>>(std::move(tmp));
+
+        auto vec = any_cast<std::vector<int>>(&a);
+
+        // ensure the value was moved
+        EXPECT_EQ(ptr, vec->data());
+
+        // ensure that the contents of the vector are unchanged
+        std::vector<int> ref{1, 2, 3};
+        EXPECT_EQ(ref, *vec);
+    }
+}


### PR DESCRIPTION
A non copyable variant of `util::any`.                                                                    
The two main use cases for such a container are                                                           
 1. storing types that are not copyable.                                                                  
 2. ensuring that no copies are made of copyable types that have to be stored                             
    in a type-erased container.                                                                           
                                                                                                          
`unique_any` has the same semantics as any with the execption of copy and copy                            
assignment, which are explicitly forbidden for all contained types.                                       
The requirement that the contained type be copy constructable has also been                               
relaxed.                                                                                                  
                                                                                                          
The `any_cast` non-member functions have been overridden for `unique_any`, with                           
the same semantics as for `any`.