### PR TITLE
Moving event delivery to back-end: multicore.

### DIFF
--- a/modcc/cprinter.cpp
+++ b/modcc/cprinter.cpp
@@ -87,8 +87,8 @@ std::string CPrinter::emit_source() {
     //////////////////////////////////////////////
     int num_vars = array_variables.size();
     text_.add_line();
-    text_.add_line(class_name + "(const_iview vec_ci, const_view vec_t, const_view vec_t_to, view vec_v, view vec_i, array&& weights, iarray&& node_index)");
-    text_.add_line(":   base(vec_ci, vec_t, vec_t_to, vec_v, vec_i, std::move(node_index))");
+    text_.add_line(class_name + "(value_type mech_id, const_iview vec_ci, const_view vec_t, const_view vec_t_to, view vec_v, view vec_i, array&& weights, iarray&& node_index)");
+    text_.add_line(":   base(mech_id, vec_ci, vec_t, vec_t_to, vec_v, vec_i, std::move(node_index))");
     text_.add_line("{");
     text_.increase_indentation();
     text_.add_gutter() << "size_type num_fields = " << num_vars << ";";

--- a/src/backends/event.hpp
+++ b/src/backends/event.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <common_types.hpp>
+
+// Structures for the representation of event delivery targets and
+// staged events.
+
+namespace nest {
+namespace mc {
+
+struct target_handle {
+    cell_local_size_type mech_id;    // mechanism type identifier (per cell group).
+    cell_local_size_type index;      // instance of the mechanism
+    cell_size_type cell_index; // which cell (acts as index into e.g. vec_t)
+
+    target_handle() {}
+    target_handle(cell_local_size_type mech_id, cell_local_size_type index, cell_size_type cell_index):
+        mech_id(mech_id), index(index), cell_index(cell_index) {}
+};
+
+struct deliverable_event {
+    time_type time;
+    target_handle handle;
+    float weight;
+
+    deliverable_event() {}
+    deliverable_event(time_type time, target_handle handle, float weight):
+        time(time), handle(handle), weight(weight) {}
+};
+
+} // namespace mc
+} // namespace nest

--- a/src/backends/event_delivery.md
+++ b/src/backends/event_delivery.md
@@ -1,0 +1,120 @@
+# Back-end event delivery
+
+## Data structures
+
+The lowered cell implementation gathers postsynaptic spike events from its governing
+`cell_group` class, and then passes them on to concrete back-end device-specific
+classes for on-device delivery.
+
+`backends/event.hpp` contains the concrete classes used to represent event
+destinations and event information.
+
+The back-end event management structure is supplied by the corresponding `backend`
+class as `backend::multi_event_stream`. It presents a limited public interface to
+the lowered cell, and is passed by reference as a parameter to 
+
+### Target handles
+
+Target handles are used by the lowered cell implementation to identify a particular mechanism
+instance that can receive events — ultimately via `net_receive` — and corresponding simulated
+cell. The cell information is given as an index into the cell group collection of cells,
+and is used to group events by integration domain (we have one domain per cell in each cell
+group).
+
+Target handles are represented by the `target_handle` struct, opaque to `mc_cell_group`,
+but created in the `fvm_multicell` for each point mechanism (synapse) in the cell group.
+
+### Deliverable events
+
+Events for delivery within the next integration period are staged in the lowered cell
+as a vector of `deliverable_event` objects. These comprise an event delivery time,
+a `target_handle` describing their destination, and a weight.
+
+### Back-end event streams
+
+`backend::multi_event_stream` represents a set (one per cell/integration domain)
+of event streams. There is one `multi_event_stream` per lowered cell.
+
+From the perspective of the lowered cell, it must support the following methods:
+
+*  `void init(const std::vector<deliverable_event>& staged_events)`
+
+   Take a copy of the staged events and initialize the streams by gathering
+   the events by cell.
+
+*  `bool empty() const`
+
+   Return true if and only if there are no un-retired events left in any stream.
+
+*  `void clear()`
+
+   Retire all events, leaving the `multi_event_stream` in an empty state.
+
+*  `void mark_until_after(const_view time)`
+
+   Mark events for delivery in each stream _i_ with event time ≤ _time[i]_.
+
+*  `void event_times_if_before(view time) const`
+
+   Set _time[i]_ to the time of the next event time in stream _i_
+   if such an event exists and has time less than _time[i]_.
+
+*  `void drop_marked_events()`
+
+   Retire all marked events.
+
+
+## Event delivery and integration timeline
+
+Event delivery is performed as part of the integration loop within the lowered
+cell implementation. The interface is provided by the `multi_event_stream`
+described above, together with the mechanism method that handles the delivery proper,
+`mechanism::deliver_events` and a `backend` static method that computes the
+integration step end time before considering any pending events.
+
+For `fvm_multicell` one integration step comprises:
+
+1.  Events for each cell that are due at that cell's corresponding time are
+    gathered with `events_.mark_events(time_)` where `time_` is a
+    `const_view` of the cell times and `events_` is a reference to the
+    `backend::multi_event_stream` object.
+
+2.  Each mechanism is requested to deliver to itself any marked events that
+    are associated with that mechanisms, via the virtual
+    `mechanism::deliver_events(backend::multi_event_stream&)` method.
+
+    This action must precede the computation of mechanism current contributions
+    with `mechanism::nrn_current()`.
+
+3.  Marked events are discarded with `events_.drop_marked_events()`.
+
+4.  The upper bound on the integration step stop time `time_to_` is
+    computed via `backend::update_time_to(time_to_, time_, dt_max_, tfinal_)`,
+    as the minimum of the per-cell time `time_` plus `dt_max_` and
+    the final integration stop time `tfinal_`.
+
+5.  The integration step stop time `time_to_` is reduced to match any
+    pending events on each cell with `events_.event_times_if_before(time_to)`.
+
+6.  The solver matrix is assembled and solved to compute the voltages, using the
+    newly computed currents and integration step times.
+
+7.  The mechanism states are updated with `mechanism::nrn_state()`.
+
+8.  The cell times `time_` are set to the integration step stop times `time_to_`.
+
+9.  Spike detection for the last integration step is performed via the
+    `threshold_watcher_` object.
+
+## Consequences for the integrator
+
+Towards the end of the integration period, an integration step may have a zero _dt_
+for one or more cells within the group, and this needs to be handled correctly:
+
+*   Generated mechanism `nrn_state()` methods should be numerically correct with
+    zero _dt_; a possibility is to guard the integration step with a _dt_ check.
+
+*   Matrix assemble and solve must check for zero _dt_. In the FVM `multicore`
+    matrix implementation, zero _dt_ sets the diagonal element to zero and the
+    rhs to the voltage; the solve procedure then ignores cells with a zero
+    diagonal element.

--- a/src/backends/multicore/multi_event_stream.hpp
+++ b/src/backends/multicore/multi_event_stream.hpp
@@ -1,0 +1,181 @@
+#pragma once
+
+// Indexed collection of pop-only event queues --- multicore back-end implementation.
+
+#include <limits>
+#include <ostream>
+#include <utility>
+
+#include <common_types.hpp>
+#include <backends/event.hpp>
+#include <util/debug.hpp>
+#include <util/range.hpp>
+#include <util/strprintf.hpp>
+
+namespace nest {
+namespace mc {
+namespace multicore {
+
+class multi_event_stream {
+public:
+    using size_type = cell_size_type;
+
+    multi_event_stream() {}
+
+    explicit multi_event_stream(size_type n_stream):
+       span_(n_stream), mark_(n_stream) {}
+
+    size_type n_streams() const { return span_.size(); }
+
+    bool empty() const { return remaining_==0; }
+
+    void clear() {
+        ev_.clear();
+        remaining_ = 0;
+
+        util::fill(span_, span_type(0u, 0u));
+        util::fill(mark_, 0u);
+    }
+
+    // Initialize event streams from a vector of `deliverable_event`.
+    void init(const std::vector<deliverable_event>& staged) {
+        if (staged.size()>std::numeric_limits<size_type>::max()) {
+            throw std::range_error("too many events");
+        }
+
+        ev_.resize(staged.size());
+        std::copy(staged.begin(), staged.end(), ev_.begin());
+
+        util::fill(span_, span_type(0u, 0u));
+        util::fill(mark_, 0u);
+
+        util::stable_sort_by(ev_, [](const deliverable_event& e) { return e.handle.cell_index; });
+
+        size_type si = 0;
+        for (size_type ev_i = 0; ev_i<ev_.size(); ++ev_i) {
+            size_type i = ev_[ev_i].handle.cell_index;
+            EXPECTS(i<n_streams());
+
+            if (si<i) {
+                // Moved on to a new cell: make empty spans for any skipped cells.
+                for (size_type j = si+1; j<i; ++j) {
+                    span_[j].second = span_[si].second;
+                }
+                si = i;
+            }
+            // Include event in this cell's span.
+            span_[si].second = ev_i+1;
+        }
+
+        while (++si<n_streams()) {
+            span_[si].second = span_[si-1].second;
+        }
+
+        for (size_type i = 1u; i<n_streams(); ++i) {
+            mark_[i] = span_[i].first = span_[i-1].second;
+        }
+
+        remaining_ = ev_.size();
+    }
+
+    // Designate for processing events `ev` at head of each event stream `i`
+    // until `event_time(ev)` > `t_until[i]`.
+    template <typename TimeSeq>
+    void mark_until_after(const TimeSeq& t_until) {
+        EXPECTS(n_streams()==util::size(t_until));
+
+        // note: operation on each `i` is independent.
+        for (size_type i = 0; i<n_streams(); ++i) {
+            auto& span = span_[i];
+            auto& mark = mark_[i];
+            auto t = t_until[i]; 
+
+            mark = span.first;
+            while (mark!=span.second && !(ev_[mark].time>t)) {
+                ++mark;
+            }
+        }
+    }
+
+    // Remove marked events from front of each event stream.
+    void drop_marked_events() {
+        // note: operation on each `i` is independent.
+        for (size_type i = 0; i<n_streams(); ++i) {
+            remaining_ -= (mark_[i]-span_[i].first);
+            span_[i].first = mark_[i];
+        }
+    }
+
+    // Return range of marked events on stream `i`.
+    util::range<deliverable_event*> marked_events(size_type i) {
+        return {&ev_[span_[i].first], &ev_[mark_[i]]};
+    }
+
+    // If the head of `i`th event stream exists and has time less than `t_until[i]`, set
+    // `t_until[i]` to the event time.
+    template <typename TimeSeq>
+    void event_time_if_before(TimeSeq& t_until) {
+        // note: operation on each `i` is independent.
+        for (size_type i = 0; i<n_streams(); ++i) {
+            const auto& span = span_[i];
+            if (span.second==span.first) {
+               continue;
+            }
+
+            auto ev_t = ev_[span.first].time;
+            if (t_until[i]>ev_t) {
+                t_until[i] = ev_t;
+            }
+        }
+    }
+
+    // TODO: remove once we are confident implementation of lowered cell event delivery
+    // is sound.
+    friend std::ostream& operator<<(std::ostream& out, const multi_event_stream& m);
+
+private:
+    using span_type = std::pair<size_type, size_type>;
+
+    std::vector<deliverable_event> ev_;
+    std::vector<span_type> span_;
+    std::vector<size_type> mark_;
+    size_type remaining_ = 0;
+};
+
+inline std::ostream& operator<<(std::ostream& out, const multi_event_stream& m) {
+    auto n = m.n_streams();
+
+    out << "\n[";
+    unsigned i = 0;
+    for (unsigned ev_i = 0; ev_i<m.ev_.size(); ++ev_i) {
+        while (m.span_[i].second<=ev_i && i<n) ++i;
+        if (i<n) {
+            out << util::strprintf(" % 7d ", i);
+        }
+        else {
+            out << "      ?";
+        }
+    }
+    out << "\n[";
+
+    i = 0;
+    for (unsigned ev_i = 0; ev_i<m.ev_.size(); ++ev_i) {
+        while (m.span_[i].second<=ev_i && i<n) ++i;
+
+        bool discarded = i<n && m.span_[i].first>ev_i;
+        bool marked = i<n && m.mark_[i]>ev_i;
+
+        if (discarded) {
+            out << "        x";
+        }
+        else {
+            out << util::strprintf(" % 7.3f%c", m.ev_[ev_i].time, marked?'*':' ');
+        }
+    }
+    out << "]\n";
+    return out;
+}
+
+} // namespace multicore
+} // namespace nest
+} // namespace mc

--- a/src/backends/multicore/stimulus.hpp
+++ b/src/backends/multicore/stimulus.hpp
@@ -28,8 +28,10 @@ public:
     using const_iview = typename base::const_iview;
     using ion_type = typename base::ion_type;
 
+    static constexpr size_type no_mech_id = (size_type)-1;
+
     stimulus(const_iview vec_ci, const_view vec_t, const_view vec_t_to, view vec_v, view vec_i, iarray&& node_index):
-        base(vec_ci, vec_t, vec_t_to, vec_v, vec_i, std::move(node_index))
+        base(no_mech_id, vec_ci, vec_t, vec_t_to, vec_v, vec_i, std::move(node_index))
     {}
 
     using base::size;

--- a/src/event_queue.hpp
+++ b/src/event_queue.hpp
@@ -10,6 +10,7 @@
 #include "common_types.hpp"
 #include "util/meta.hpp"
 #include "util/optional.hpp"
+#include "util/range.hpp"
 #include "util/strprintf.hpp"
 
 namespace nest {
@@ -135,139 +136,6 @@ private:
         std::vector<Event>,
         event_greater
     > queue_;
-};
-
-// Indexed collection of pop-only queues.
-// 'flat' implementation below is acting as a prototype for GPU back-end.
-
-template <typename Event>
-class multi_event_stream {
-public:
-    using value_type = Event;
-    using time_type = impl::event_time_type<Event>;
-    using size_type = unsigned;
-
-    multi_event_stream() {}
-
-    explicit multi_event_stream(size_type n_stream):
-       span_(n_stream, {0u, 0u}) {}
-
-    size_type n_streams() const { return span_.size(); }
-    size_type size() const { return n_streams(); }
-
-    size_type n_events(size_type i) const {
-        auto span = span_[i];
-        return span.second-span.first;
-    }
-
-    size_type remaining() const {
-        return remaining_;
-    }
-
-    void clear() {
-        ev_.clear();
-        remaining_ = 0;
-        span_.assign(n_streams(), {0u, 0u});
-    }
-
-    // Load events from a sequence (of length at least `size()`) of
-    // sequences of events.
-    template <typename EvSeqs>
-    void init(const EvSeqs& events) {
-        using std::begin;
-        using std::end;
-
-        EXPECTS(n_streams()==util::size(events));
-
-        remaining_ = 0;
-        auto evi = begin(events);
-        for (size_type i = 0; i<n_streams(); ++i) {
-            if (evi != end(events)) {
-                span_[i].first = size_type(ev_.size());
-                ev_.insert(ev_.end(), begin(*evi), end(*evi));
-                span_[i].second = size_type(ev_.size());
-                ++evi;
-
-                // check size for wrapping!
-                if (ev_.size()>std::numeric_limits<size_type>::max()) {
-                    throw std::range_error("too many events");
-                }
-            }
-            else {
-                span_[i] = {0u, 0u};
-            }
-        }
-        remaining_ = ev_.size();
-    }
-
-    // Pop and return top event `ev` of `i`th event stream unless `event_time(ev)` > `t_until`
-    util::optional<value_type> pop_if_not_after(size_type i, time_type t_until) {
-        using ::nest::mc::event_time;
-        return pop_if(i,
-            [&t_until](const value_type& ev) { return !(event_time(ev) > t_until); }
-        );
-    }
-
-    // Return time of head of `i`th event stream if less than `t_until`, or else `t_until`.
-    time_type event_time_if_before(size_type i, const time_type& t_until) {
-        if (!n_events(i)) {
-            return t_until;
-        }
-
-        using ::nest::mc::event_time;
-        auto t = event_time(top_unsafe(i));
-        return t_until > t? t: t_until;
-    }
-
-    // Generic conditional pop: pop and return head of `i`th stream if
-    // non-empty and the head satisfies predicate.
-    template <typename Pred>
-    util::optional<value_type> pop_if(size_type i, Pred&& pred) {
-        if (n_events(i) && pred(top_unsafe(i))) {
-            return pop_unsafe(i);
-        }
-        else {
-            return util::nothing;
-        }
-    }
-
-    // TODO: remove once we are confident implementation of lowered cell event delivery
-    // is sound.
-    friend std::ostream& operator<<(std::ostream& out, const multi_event_stream& m) {
-        using ::nest::mc::event_time;
-
-        out << "[\n";
-        for (size_type s = 0; s<m.n_streams(); ++s) {
-            out << util::strprintf("%05d: ", (int)s);
-
-            unsigned prev_end = 0;
-            for (const auto& p: m.span_) {
-                for (unsigned i = prev_end; i<p.first; ++i) {
-                    out << "      x";
-                }
-                for (unsigned i = p.first; i<p.second; ++i) {
-                    out << util::strprintf(" % 6.3f", event_time(m.ev_[i]));
-                }
-            }
-            out << "\n";
-        }
-        out << "]\n";
-        return out;
-    }
-
-private:
-    const value_type& top_unsafe(size_type i) const {
-        return ev_[span_[i].first];
-    }
-
-    value_type pop_unsafe(size_type i) {
-        --remaining_;
-        return std::move(ev_[span_[i].first++]);
-    }
-
-    std::vector<value_type> ev_;
-    std::vector<std::pair<size_type, size_type>> span_;
-    size_type remaining_ = 0;
 };
 
 } // namespace nest

--- a/src/fvm_multicell.hpp
+++ b/src/fvm_multicell.hpp
@@ -265,7 +265,7 @@ private:
     bool integration_running_ = false;
 
     /// events staged for upcoming integration stage
-    std::vector<std::vector<deliverable_event>> staged_events_;
+    std::vector<deliverable_event> staged_events_;
 
     /// event queue for integration period
     using multi_event_stream = typename backend::multi_event_stream;

--- a/src/mechanism.hpp
+++ b/src/mechanism.hpp
@@ -39,7 +39,7 @@ public:
 
     using ion_type = ion<backend>;
 
-    mechanism(value_type mech_id, const_iview vec_ci, const_view vec_t, const_view vec_t_to, view vec_v, view vec_i, iarray&& node_index):
+    mechanism(size_type mech_id, const_iview vec_ci, const_view vec_t, const_view vec_t_to, view vec_v, view vec_i, iarray&& node_index):
         mech_id_(mech_id),
         vec_ci_(vec_ci),
         vec_t_(vec_t),

--- a/src/util/debug.hpp
+++ b/src/util/debug.hpp
@@ -86,6 +86,9 @@ namespace impl {
     };
 }
 
+// Wrap a sequence or container of values so that they can be printed
+// to an `std::ostream` with the elements separated by the supplied 
+// separator.
 template <typename Seq, typename Separator>
 impl::sepval<Seq, Separator> sepval(const Seq& seq, Separator sep) {
     return impl::sepval<Seq, Separator>(seq, std::move(sep));

--- a/src/util/debug.hpp
+++ b/src/util/debug.hpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <sstream>
 #include <mutex>
+#include <utility>
 
 #include <threading/threading.hpp>
 #include "unwind.hpp"
@@ -63,6 +64,31 @@ void debug_emit_trace(const char* file, int line, const char* varlist, const Arg
         debug_emit(std::cerr, args...);
         std::cerr.flush();
     }
+}
+
+namespace impl {
+    template <typename Seq, typename Separator>
+    struct sepval {
+        const Seq& seq;
+        Separator sep;
+
+        sepval(const Seq& seq, Separator sep): seq(seq), sep(std::move(sep)) {}
+
+        friend std::ostream& operator<<(std::ostream& out, const sepval& sv) {
+            bool emitsep = false;
+            for (const auto& v: sv.seq) {
+                if (emitsep) out << sv.sep;
+                emitsep = true;
+                out << v;
+            }
+            return out;
+        }
+    };
+}
+
+template <typename Seq, typename Separator>
+impl::sepval<Seq, Separator> sepval(const Seq& seq, Separator sep) {
+    return impl::sepval<Seq, Separator>(seq, std::move(sep));
 }
 
 } // namespace util

--- a/tests/unit/test_mechanisms.cpp
+++ b/tests/unit/test_mechanisms.cpp
@@ -47,7 +47,7 @@ TEST(mechanisms, helpers) {
     multicore::backend::array vec_t(ncell, 0.);
     multicore::backend::array vec_t_to(ncell, 0.);
 
-    auto mech = multicore::backend::make_mechanism("hh",
+    auto mech = multicore::backend::make_mechanism("hh", 0,
             memory::make_view(cell_index), vec_t, vec_t_to,
             vec_v, vec_i, weights, node_index);
 
@@ -56,7 +56,7 @@ TEST(mechanisms, helpers) {
 
     // check that an out_of_range exception is thrown if an invalid mechanism is requested
     ASSERT_THROW(
-        multicore::backend::make_mechanism("dachshund",
+        multicore::backend::make_mechanism("dachshund", 0,
             memory::make_view(cell_index), vec_t, vec_t_to,
             vec_v, vec_i, weights, node_index),
         std::out_of_range
@@ -178,12 +178,12 @@ TYPED_TEST_P(mechanisms, update) {
 
     // Create mechanisms
     auto mech = nest::mc::mechanisms::make_mechanism<mechanism_type>(
-        cell_index, time, time_to,
+        0, cell_index, time, time_to,
         voltage, current, std::move(weights), std::move(node_index)
     );
 
     auto mech_proto = nest::mc::mechanisms::make_mechanism<proto_mechanism_type>(
-        cell_index, time, time_to,
+        0, cell_index, time, time_to,
         voltage_copy, current_copy,
         std::move(weights_copy), std::move(node_index_copy)
     );

--- a/tests/unit/test_synapses.cpp
+++ b/tests/unit/test_synapses.cpp
@@ -61,7 +61,7 @@ TEST(synapses, expsyn_basic_state)
     synapse_type::array voltage(num_comp, -65.0);
     synapse_type::array current(num_comp,   1.0);
 
-    auto mech = mechanisms::make_mechanism<synapse_type>(cell_index, time, time_to, voltage, current, weights, node_index);
+    auto mech = mechanisms::make_mechanism<synapse_type>(0, cell_index, time, time_to, voltage, current, weights, node_index);
     auto ptr = dynamic_cast<synapse_type*>(mech.get());
 
     auto n = ptr->size();
@@ -121,7 +121,7 @@ TEST(synapses, exp2syn_basic_state)
     synapse_type::array voltage(num_comp, -65.0);
     synapse_type::array current(num_comp,   1.0);
 
-    auto mech = mechanisms::make_mechanism<synapse_type>(cell_index, time, time_to, voltage, current, weights, node_index);
+    auto mech = mechanisms::make_mechanism<synapse_type>(0, cell_index, time, time_to, voltage, current, weights, node_index);
     auto ptr = dynamic_cast<synapse_type*>(mech.get());
 
     auto n = ptr->size();


### PR DESCRIPTION
Defines the back-end event-delivery abstraction and provides an implementation for `multicore`. Breaks `gpu` back-end.

* Move `multi_event_stream` to `src/backends/multicore/multi_event_stream.hpp`.
* Simplify building process of `multi_event_stream`.
* Move common event-delivery types (`target_handle`, `deliverable_event`) to `src/backends/event.hpp`.
* Add zero-dt check/support to `multicore::matrix_state`.
* Add debugging helper `util::sepval` for printing/tracing container values.
* Fix end-of-integration check in `fvm_multicell`.
* Document event delivery process and abstraction in `src/backends/event_delivery.md`.