### PR TITLE
Restore option summary output to miniapp.

### DIFF
--- a/miniapp/io.cpp
+++ b/miniapp/io.cpp
@@ -183,9 +183,15 @@ cl_options read_options(int argc, char** argv, bool allow_write) {
             false, defopts.dry_run_ranks, "positive integer", cmd);
         TCLAP::SwitchArg profile_only_zero_arg(
              "z", "profile-only-zero", "Only output profile information for rank 0", cmd, false);
+        TCLAP::SwitchArg verbose_arg(
+             "v", "verbose", "Present more verbose information to stdout", cmd, false);
 
         cmd.reorder_arguments();
         cmd.parse(argc, argv);
+
+        // Handle verbosity separately from other options: it is not considered part
+        // of the saved option state.
+        options.verbose = verbose_arg.getValue();
 
         std::string ifile_name = ifile_arg.getValue();
         if (ifile_name != "") {
@@ -324,6 +330,12 @@ cl_options read_options(int argc, char** argv, bool allow_write) {
             throw usage_error("unable to write to model parameter file "+save_file);
         }
     }
+
+    // If verbose output requested, emit option summary.
+    if (options.verbose) {
+        std::cout << options << "\n";
+    }
+
     return options;
 }
 

--- a/miniapp/io.hpp
+++ b/miniapp/io.hpp
@@ -57,6 +57,9 @@ struct cl_options {
 
     // Report (inefficiently) on number of cell compartments in sim.
     bool report_compartments = false;
+
+    // Be more verbose with informational messages.
+    bool verbose = false;
 };
 
 class usage_error: public std::runtime_error {


### PR DESCRIPTION
Fixes #263.

* Add 'verbose' field to command line option struct, set with '-v'.
* If verbose flag is true, emit option summary to stdout.