### PR TITLE
pade approximation of exp in cnexp integration

### DIFF
--- a/modcc/module.hpp
+++ b/modcc/module.hpp
@@ -109,6 +109,10 @@ private:
         return s == symbols_.end() ? false : s->second->kind() == kind;
     }
 
+    // Perform semantic analysis on functions and procedures.
+    // Returns the number of errors that were encountered.
+    int semantic_func_proc();
+
     // blocks
     NeuronBlock neuron_block_;
     StateBlock  state_block_;

--- a/modcc/solvers.cpp
+++ b/modcc/solvers.cpp
@@ -70,7 +70,7 @@ void CnexpSolverVisitor::visit(AssignmentExpression *e) {
         statements_.push_back(std::move(local_a_term.assignment));
         auto a_ = local_a_term.id->is_identifier()->spelling();
 
-        std::string s_update = pprintf("% = %*exp(%*dt)", s, s, a_);
+        std::string s_update = pprintf("% = %*exp_pade_11(%*dt)", s, s, a_);
         statements_.push_back(Parser{s_update}.parse_line_expression());
         return;
     }
@@ -111,7 +111,7 @@ void CnexpSolverVisitor::visit(AssignmentExpression *e) {
             statements_.push_back(std::move(local_b_term.local_decl));
             statements_.push_back(std::move(local_b_term.assignment));
 
-            std::string s_update = pprintf("% = %+(%-%)*exp(-dt/%)", s, b_, s, b_, a_);
+            std::string s_update = pprintf("% = %+(%-%)*exp_pade_11(-dt/%)", s, b_, s, b_, a_);
             statements_.push_back(Parser{s_update}.parse_line_expression());
             return;
         }
@@ -130,7 +130,7 @@ not_gating:
         statements_.push_back(std::move(local_ba_term.local_decl));
         statements_.push_back(std::move(local_ba_term.assignment));
 
-        std::string s_update = pprintf("% = -%+(%+%)*exp(%*dt)", s, ba_, s, ba_, a_);
+        std::string s_update = pprintf("% = -%+(%+%)*exp_pade_11(%*dt)", s, ba_, s, ba_, a_);
         statements_.push_back(Parser{s_update}.parse_line_expression());
         return;
     }


### PR DESCRIPTION
This PR replaces the expensive call to `exp` when integrating dependent variables in the cnexp method with a 2nd order pade approximation.

  * modcc inserts `exp_pade_11` and `exp_pade_22` functions into every module, which define pade approximations of 2nd and 4th order respectively (m=n=1 and m=n=2).
  * the generated solver code calls the `exp_pade_11` function instead of the built in `exp` unary operator

The validation tests pass for both the 2nd and 4th order approximations, so we we go with the 2nd order.

fixes #265 