### PR TITLE
simplify generated x86 code

### DIFF
--- a/modcc/cprinter.cpp
+++ b/modcc/cprinter.cpp
@@ -336,9 +336,7 @@ std::string CPrinter::emit_source() {
     text_.add_line("array data_;");
     for(auto var: array_variables) {
         if(optimize_) {
-            text_.add_line(
-                "__declspec(align(array::alignment())) value_type *"
-                + var->name() + ";");
+            text_.add_line("value_type *" + var->name() + ";");
         }
         else {
             text_.add_line("view " + var->name() + ";");
@@ -661,13 +659,7 @@ void CPrinter::emit_api_loop(APIMethod* e,
 }
 
 void CPrinter::print_APIMethod_unoptimized(APIMethod* e) {
-    // there can not be more than 1 instance of a density channel per grid point,
-    // so we can assert that aliasing will not occur.
-    if(optimize_) text_.add_line("#pragma ivdep");
-
     emit_api_loop(e, "int i_ = 0", "i_ < n_", "++i_");
-
-    //text_.add_line("STOP_PROFILE");
     decrease_indentation();
 
     return;
@@ -709,11 +701,8 @@ void CPrinter::print_APIMethod_optimized(APIMethod* e) {
     text_.add_line("constexpr int BSIZE = 4;");
     text_.add_line("int NB = n_/BSIZE;");
     for(auto out: aliased_variables) {
-        text_.add_line(
-            "__declspec(align(array::alignment())) value_type "
-            + out->name() +  "[BSIZE];");
+        text_.add_line("value_type " + out->name() +  "[BSIZE];");
     }
-    //text_.add_line("START_PROFILE");
 
     text_.add_line("for(int b_=0; b_<NB; ++b_) {");
     text_.increase_indentation();
@@ -721,10 +710,6 @@ void CPrinter::print_APIMethod_optimized(APIMethod* e) {
     text_.add_line("int i_ = BSTART;");
 
 
-    // assert that memory accesses are not aliased because we will
-    // use ghost arrays to ensure that write-back of point processes does
-    // not lead to race conditions
-    text_.add_line("#pragma ivdep");
     text_.add_line("for(int j_=0; j_<BSIZE; ++j_, ++i_) {");
     text_.increase_indentation();
 
@@ -767,7 +752,6 @@ void CPrinter::print_APIMethod_optimized(APIMethod* e) {
     // ------------- block tail loop ------------- //
 
     text_.add_line("int j_ = 0;");
-    text_.add_line("#pragma ivdep");
     text_.add_line("for(int i_=NB*BSIZE; i_<n_; ++j_, ++i_) {");
     text_.increase_indentation();
 
@@ -803,7 +787,6 @@ void CPrinter::print_APIMethod_optimized(APIMethod* e) {
     text_.decrease_indentation();
     text_.add_line("}"); // end block tail loop
 
-    //text_.add_line("STOP_PROFILE");
     decrease_indentation();
 
     aliased_output_ = false;

--- a/modcc/module.hpp
+++ b/modcc/module.hpp
@@ -109,6 +109,10 @@ private:
         return s == symbols_.end() ? false : s->second->kind() == kind;
     }
 
+    // Perform semantic analysis on functions and procedures.
+    // Returns the number of errors that were encountered.
+    int semantic_func_proc();
+
     // blocks
     NeuronBlock neuron_block_;
     StateBlock  state_block_;

--- a/modcc/solvers.cpp
+++ b/modcc/solvers.cpp
@@ -70,7 +70,7 @@ void CnexpSolverVisitor::visit(AssignmentExpression *e) {
         statements_.push_back(std::move(local_a_term.assignment));
         auto a_ = local_a_term.id->is_identifier()->spelling();
 
-        std::string s_update = pprintf("% = %*exp(%*dt)", s, s, a_);
+        std::string s_update = pprintf("% = %*exp_pade_11(%*dt)", s, s, a_);
         statements_.push_back(Parser{s_update}.parse_line_expression());
         return;
     }
@@ -111,7 +111,7 @@ void CnexpSolverVisitor::visit(AssignmentExpression *e) {
             statements_.push_back(std::move(local_b_term.local_decl));
             statements_.push_back(std::move(local_b_term.assignment));
 
-            std::string s_update = pprintf("% = %+(%-%)*exp(-dt/%)", s, b_, s, b_, a_);
+            std::string s_update = pprintf("% = %+(%-%)*exp_pade_11(-dt/%)", s, b_, s, b_, a_);
             statements_.push_back(Parser{s_update}.parse_line_expression());
             return;
         }
@@ -130,7 +130,7 @@ not_gating:
         statements_.push_back(std::move(local_ba_term.local_decl));
         statements_.push_back(std::move(local_ba_term.assignment));
 
-        std::string s_update = pprintf("% = -%+(%+%)*exp(%*dt)", s, ba_, s, ba_, a_);
+        std::string s_update = pprintf("% = -%+(%+%)*exp_pade_11(%*dt)", s, ba_, s, ba_, a_);
         statements_.push_back(Parser{s_update}.parse_line_expression());
         return;
     }


### PR DESCRIPTION
Remove some old compiler directives and properties from modcc-generated kernels that were not used by the intel compiler, and were not recognised by gcc.

Now the optimized x86 kernels can be compiled by both gcc and intel compilers.