### PR TITLE
tiny fix to work around gcc bug on ppc

### DIFF
--- a/lmorpho/lsystem.cpp
+++ b/lmorpho/lsystem.cpp
@@ -203,7 +203,7 @@ struct grow_result {
     double length = 0.;
 };
 
-constexpr double deg_to_rad = 3.1415926535897932384626433832795l/180.0;
+constexpr double deg_to_rad = 3.1415926535897932384626433832795/180.0;
 
 template <typename Gen>
 grow_result grow(section_tip tip, const lsys_sampler& S, Gen &g) {


### PR DESCRIPTION
GCC has a power-pc specific bug

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=26374

This is simple to workaround: remove `l` from a double literal in a `constexpr` expression.