### PR TITLE
Fix target to handle synapse assignment.

### DIFF
--- a/tests/unit/test_fvm_multi.cpp
+++ b/tests/unit/test_fvm_multi.cpp
@@ -414,9 +414,24 @@ TEST(fvm_multi, target_handles_onecell)
     run_target_handle_test(handles1);
 }
 
-TEST(fvm_multi, target_handles_twocell)
+TEST(fvm_multi, target_handles_twocell_sorted)
 {
-    SCOPED_TRACE("handles: expsyn only on cells 0 and 1");
+    SCOPED_TRACE("handles: expsyn only on cells 0 and 1, cvs sorted");
+    std::vector<handle_info> handles = {
+        {0, "expsyn",  0},
+        {0, "expsyn",  2},
+        {0, "expsyn",  4},
+        {1, "expsyn",  1},
+        {1, "expsyn",  2},
+        {1, "expsyn",  3},
+        {1, "expsyn",  4}
+    };
+    run_target_handle_test(handles);
+}
+
+TEST(fvm_multi, target_handles_twocell_unsorted)
+{
+    SCOPED_TRACE("handles: expsyn only on cells 0 and 1, cvs unsorted");
     std::vector<handle_info> handles = {
         {0, "expsyn",  4},
         {1, "expsyn",  4},

--- a/tests/unit/test_fvm_multi.cpp
+++ b/tests/unit/test_fvm_multi.cpp
@@ -414,24 +414,9 @@ TEST(fvm_multi, target_handles_onecell)
     run_target_handle_test(handles1);
 }
 
-TEST(fvm_multi, target_handles_twocell_sorted)
+TEST(fvm_multi, target_handles_twocell)
 {
-    SCOPED_TRACE("handles: expsyn only on cells 0 and 1, cvs sorted");
-    std::vector<handle_info> handles = {
-        {0, "expsyn",  0},
-        {0, "expsyn",  2},
-        {0, "expsyn",  4},
-        {1, "expsyn",  1},
-        {1, "expsyn",  2},
-        {1, "expsyn",  3},
-        {1, "expsyn",  4}
-    };
-    run_target_handle_test(handles);
-}
-
-TEST(fvm_multi, target_handles_twocell_unsorted)
-{
-    SCOPED_TRACE("handles: expsyn only on cells 0 and 1, cvs unsorted");
+    SCOPED_TRACE("handles: expsyn only on cells 0 and 1");
     std::vector<handle_info> handles = {
         {0, "expsyn",  4},
         {1, "expsyn",  4},

--- a/tests/unit/test_fvm_multi.cpp
+++ b/tests/unit/test_fvm_multi.cpp
@@ -396,29 +396,33 @@ void run_target_handle_test(std::vector<handle_info> all_handles) {
 
 TEST(fvm_multi, target_handles_onecell)
 {
-    SCOPED_TRACE("handles: exp2syn only on cell 0");
-    std::vector<handle_info> handles0 = {
-        {0, "exp2syn",  4},
-        {0, "exp2syn",  4},
-        {0, "exp2syn",  3},
-        {0, "exp2syn",  2},
-        {0, "exp2syn",  0},
-        {0, "exp2syn",  1},
-        {0, "exp2syn",  2}
-    };
-    run_target_handle_test(handles0);
+    {
+        SCOPED_TRACE("handles: exp2syn only on cell 0");
+        std::vector<handle_info> handles0 = {
+            {0, "exp2syn",  4},
+            {0, "exp2syn",  4},
+            {0, "exp2syn",  3},
+            {0, "exp2syn",  2},
+            {0, "exp2syn",  0},
+            {0, "exp2syn",  1},
+            {0, "exp2syn",  2}
+        };
+        run_target_handle_test(handles0);
+    }
 
-    SCOPED_TRACE("handles: expsyn only on cell 1");
-    std::vector<handle_info> handles1 = {
-        {1, "expsyn",  4},
-        {1, "expsyn",  4},
-        {1, "expsyn",  3},
-        {1, "expsyn",  2},
-        {1, "expsyn",  0},
-        {1, "expsyn",  1},
-        {1, "expsyn",  2}
-    };
-    run_target_handle_test(handles1);
+    {
+        SCOPED_TRACE("handles: expsyn only on cell 1");
+        std::vector<handle_info> handles1 = {
+            {1, "expsyn",  4},
+            {1, "expsyn",  4},
+            {1, "expsyn",  3},
+            {1, "expsyn",  2},
+            {1, "expsyn",  0},
+            {1, "expsyn",  1},
+            {1, "expsyn",  2}
+        };
+        run_target_handle_test(handles1);
+    }
 }
 
 TEST(fvm_multi, target_handles_twocell)


### PR DESCRIPTION
Fixes #273.

Note: this incorporates the unit test patch in PR #275.

* Store index into targets collection with synapse CV before sorting, and use this target index to store the permuted instance index in the correct target slot.