### PR TITLE
Fix consistency issue of the SIMD i/f of modcc

### DIFF
--- a/modcc/backends/avx512.hpp
+++ b/modcc/backends/avx512.hpp
@@ -121,7 +121,7 @@ struct simd_intrinsics<targetKind::avx512> {
     static void emit_gather(TextBuffer& tb, const A& addr,
                             const I& index, const S& scale) {
         tb << "_mm512_i32gather_pd(";
-        emit_operands(tb, arg_emitter(addr), arg_emitter(index),
+        emit_operands(tb, arg_emitter(index), arg_emitter(addr),
                       arg_emitter(scale));
         tb << ")";
     }

--- a/modcc/options.hpp
+++ b/modcc/options.hpp
@@ -7,7 +7,7 @@ enum class targetKind {
     cpu,
     gpu,
     // Vectorisation targets
-    avx512,
+    avx512
  };
 
 struct Options {

--- a/modcc/simd_printer.hpp
+++ b/modcc/simd_printer.hpp
@@ -377,7 +377,7 @@ void SimdPrinter<Arch>::visit(IndexedVariable *e) {
         value_name = emit_rawptr_name(e->index_name());
     }
 
-    simd_backend::emit_gather(text_, vindex_name, value_name, "sizeof(value_type)");
+    simd_backend::emit_gather(text_, value_name, vindex_name, "sizeof(value_type)");
 }
 
 template<targetKind Arch>


### PR DESCRIPTION
The `emit_gather()` function emitted the "wrong" instruction in terms of its
arguments but the instruction actually generated was correct, because
the `simd_printer` was passing the arguments to `emit_gather()` in a
different order, which was though the correct order for the finally emitted
instruction. Complicated? This commit cleans this up.

This is not an exposed bug, but it could easily become one.