### PR TITLE
GPU back-end event delivery implementation.

### DIFF
--- a/miniapp/io.cpp
+++ b/miniapp/io.cpp
@@ -158,6 +158,9 @@ cl_options read_options(int argc, char** argv, bool allow_write) {
         TCLAP::ValueArg<uint32_t> group_size_arg(
             "g", "group-size", "number of cells per cell group",
             false, defopts.compartments_per_segment, "integer", cmd);
+        TCLAP::ValueArg<double> sample_dt_arg(
+            "", "sample-dt", "set sampling interval to <time> ms",
+            false, defopts.bin_dt, "time", cmd);
         TCLAP::ValueArg<double> probe_ratio_arg(
             "p", "probe-ratio", "proportion between 0 and 1 of cells to probe",
             false, defopts.probe_ratio, "proportion", cmd);
@@ -211,6 +214,7 @@ cl_options read_options(int argc, char** argv, bool allow_write) {
                     update_option(options.all_to_all, fopts, "all_to_all");
                     update_option(options.ring, fopts, "ring");
                     update_option(options.group_size, fopts, "group_size");
+                    update_option(options.sample_dt, fopts, "sample_dt");
                     update_option(options.probe_ratio, fopts, "probe_ratio");
                     update_option(options.probe_soma_only, fopts, "probe_soma_only");
                     update_option(options.trace_prefix, fopts, "trace_prefix");
@@ -256,6 +260,7 @@ cl_options read_options(int argc, char** argv, bool allow_write) {
         update_option(options.all_to_all, all_to_all_arg);
         update_option(options.ring, ring_arg);
         update_option(options.group_size, group_size_arg);
+        update_option(options.sample_dt, sample_dt_arg);
         update_option(options.probe_ratio, probe_ratio_arg);
         update_option(options.probe_soma_only, probe_soma_only_arg);
         update_option(options.trace_prefix, trace_prefix_arg);
@@ -304,6 +309,7 @@ cl_options read_options(int argc, char** argv, bool allow_write) {
                 fopts["all_to_all"] = options.all_to_all;
                 fopts["ring"] = options.ring;
                 fopts["group_size"] = options.group_size;
+                fopts["sample_dt"] = options.sample_dt;
                 fopts["probe_ratio"] = options.probe_ratio;
                 fopts["probe_soma_only"] = options.probe_soma_only;
                 fopts["trace_prefix"] = options.trace_prefix;
@@ -350,6 +356,7 @@ std::ostream& operator<<(std::ostream& o, const cl_options& options) {
     o << "  all to all network   : " << (options.all_to_all ? "yes" : "no") << "\n";
     o << "  ring network         : " << (options.ring ? "yes" : "no") << "\n";
     o << "  group size           : " << options.group_size << "\n";
+    o << "  sample dt            : " << options.sample_dt << "\n";
     o << "  probe ratio          : " << options.probe_ratio << "\n";
     o << "  probe soma only      : " << (options.probe_soma_only ? "yes" : "no") << "\n";
     o << "  trace prefix         : " << options.trace_prefix << "\n";

--- a/miniapp/io.hpp
+++ b/miniapp/io.hpp
@@ -41,7 +41,7 @@ struct cl_options {
     double probe_ratio = 0;  // Proportion of cells to probe.
     std::string trace_prefix = "trace_";
     util::optional<unsigned> trace_max_gid; // Only make traces up to this gid.
-    std::string trace_format = "json"; // Supportint only 'json' and 'csv'.
+    std::string trace_format = "json"; // Support only 'json' and 'csv'.
 
     // Parameters for spike output.
     bool spike_file_output = false;

--- a/miniapp/io.hpp
+++ b/miniapp/io.hpp
@@ -40,6 +40,7 @@ struct cl_options {
     double probe_ratio = 0;  // Proportion of cells to probe.
     std::string trace_prefix = "trace_";
     util::optional<unsigned> trace_max_gid; // Only make traces up to this gid.
+    std::string trace_format = "json"; // Supportint only 'json' and 'csv'.
 
     // Parameters for spike output.
     bool spike_file_output = false;

--- a/miniapp/io.hpp
+++ b/miniapp/io.hpp
@@ -36,6 +36,7 @@ struct cl_options {
     double bin_dt = 0.0025;   // 0 => no binning.
 
     // Probe/sampling specification.
+    double sample_dt = 0.1;
     bool probe_soma_only = false;
     double probe_ratio = 0;  // Proportion of cells to probe.
     std::string trace_prefix = "trace_";

--- a/miniapp/miniapp.cpp
+++ b/miniapp/miniapp.cpp
@@ -123,8 +123,7 @@ int main(int argc, char** argv) {
 
         // Attach samplers to all probes
         std::vector<std::unique_ptr<sample_trace_type>> traces;
-        //const time_type sample_dt = 0.1;
-        const time_type sample_dt = options.dt;
+        const time_type sample_dt = options.sample_dt;
         for (auto probe: m.probes()) {
             if (options.trace_max_gid && probe.id.gid>*options.trace_max_gid) {
                 continue;

--- a/modcc/cprinter.cpp
+++ b/modcc/cprinter.cpp
@@ -88,7 +88,7 @@ std::string CPrinter::emit_source() {
     //////////////////////////////////////////////
     int num_vars = array_variables.size();
     text_.add_line();
-    text_.add_line(class_name + "(value_type mech_id, const_iview vec_ci, const_view vec_t, const_view vec_t_to, view vec_v, view vec_i, array&& weights, iarray&& node_index)");
+    text_.add_line(class_name + "(size_type mech_id, const_iview vec_ci, const_view vec_t, const_view vec_t_to, view vec_v, view vec_i, array&& weights, iarray&& node_index)");
     text_.add_line(":   base(mech_id, vec_ci, vec_t, vec_t_to, vec_v, vec_i, std::move(node_index))");
     text_.add_line("{");
     text_.increase_indentation();

--- a/modcc/cprinter.cpp
+++ b/modcc/cprinter.cpp
@@ -60,6 +60,7 @@ std::string CPrinter::emit_source() {
     text_.add_line("using const_view = typename base::const_view;");
     text_.add_line("using const_iview = typename base::const_iview;");
     text_.add_line("using ion_type = typename base::ion_type;");
+    text_.add_line("using multi_event_stream = typename base::multi_event_stream;");
     text_.add_line();
 
     //////////////////////////////////////////////
@@ -317,15 +318,34 @@ std::string CPrinter::emit_source() {
     auto proctest = [] (procedureKind k) {
         return is_in(k, {procedureKind::normal, procedureKind::api, procedureKind::net_receive});
     };
+    bool override_deliver_events = false;
     for(auto const& var: module_->symbols()) {
         auto isproc = var.second->kind()==symbolKind::procedure;
-        if(isproc )
-        {
+        if(isproc) {
             auto proc = var.second->is_procedure();
             if(proctest(proc->kind())) {
                 proc->accept(this);
             }
+            override_deliver_events |= proc->kind()==procedureKind::net_receive;
         }
+    }
+
+    if(override_deliver_events) {
+        text_.add_line("void deliver_events(multi_event_stream& events) override {");
+        text_.increase_indentation();
+        text_.add_line("auto ncell = events.n_streams();");
+        text_.add_line("for (size_type c = 0; c<ncell; ++c) {");
+        text_.increase_indentation();
+        text_.add_line("for (auto ev: events.marked_events(c)) {");
+        text_.increase_indentation();
+        text_.add_line("if (ev.handle.mech_id==mech_id_) net_receive(ev.handle.index, ev.weight);");
+        text_.decrease_indentation();
+        text_.add_line("}");
+        text_.decrease_indentation();
+        text_.add_line("}");
+        text_.decrease_indentation();
+        text_.add_line("}");
+        text_.add_line();
     }
 
     //////////////////////////////////////////////
@@ -357,6 +377,7 @@ std::string CPrinter::emit_source() {
     }
 
     text_.add_line();
+    text_.add_line("using base::mech_id_;");
     text_.add_line("using base::vec_ci_;");
     text_.add_line("using base::vec_t_;");
     text_.add_line("using base::vec_t_to_;");
@@ -383,6 +404,7 @@ void CPrinter::emit_headers() {
     text_.add_line();
     text_.add_line("#include <mechanism.hpp>");
     text_.add_line("#include <algorithms.hpp>");
+    text_.add_line("#include <backends/multicore/multi_event_stream.hpp>");
     text_.add_line("#include <util/pprintf.hpp>");
     text_.add_line();
 }

--- a/modcc/cudaprinter.cpp
+++ b/modcc/cudaprinter.cpp
@@ -42,6 +42,7 @@ CUDAPrinter::CUDAPrinter(Module &m, bool o)
     text_.add_line("#include <mechanism.hpp>");
     text_.add_line("#include <algorithms.hpp>");
     text_.add_line("#include <backends/gpu/intrinsics.hpp>");
+    text_.add_line("#include <backends/gpu/multi_event_stream.hpp>");
     text_.add_line("#include <util/pprintf.hpp>");
     text_.add_line();
 
@@ -111,6 +112,7 @@ CUDAPrinter::CUDAPrinter(Module &m, bool o)
     text_.add_line("namespace kernels {");
     {
         increase_indentation();
+        text_.add_line("using nest::mc::gpu::multi_event_stream;");
 
         // forward declarations of procedures
         for(auto const &var : m.symbols()) {
@@ -157,6 +159,7 @@ CUDAPrinter::CUDAPrinter(Module &m, bool o)
     text_.add_line("using typename base::const_iview;");
     text_.add_line("using typename base::const_view;");
     text_.add_line("using typename base::ion_type;");
+    text_.add_line("using multi_event_stream = typename base::multi_event_stream;");
     text_.add_line("using param_pack_type = " + module_name + "_ParamPack<value_type, size_type>;");
 
     //////////////////////////////////////////////
@@ -186,8 +189,8 @@ CUDAPrinter::CUDAPrinter(Module &m, bool o)
 
     int num_vars = array_variables.size();
     text_.add_line();
-    text_.add_line(class_name + "(const_iview vec_ci, const_view vec_t, const_view vec_t_to, view vec_v, view vec_i, array&& weights, iarray&& node_index):");
-    text_.add_line("   base(vec_ci, vec_t, vec_t_to, vec_v, vec_i, std::move(node_index))");
+    text_.add_line(class_name + "(value_type mech_id, const_iview vec_ci, const_view vec_t, const_view vec_t_to, view vec_v, view vec_i, array&& weights, iarray&& node_index):");
+    text_.add_line("   base(mech_id, vec_ci, vec_t, vec_t_to, vec_v, vec_i, std::move(node_index))");
     text_.add_line("{");
     text_.increase_indentation();
     text_.add_gutter() << "size_type num_fields = " << num_vars << ";";
@@ -435,15 +438,23 @@ CUDAPrinter::CUDAPrinter(Module &m, bool o)
         else if( var.second->kind()==symbolKind::procedure &&
                  var.second->is_procedure()->kind()==procedureKind::net_receive)
         {
-            // Simplest net_receive implementation forwards a single update
-            // to a GPU kernel.
-            auto proc = var.second->is_procedure();
-            auto name = proc->name();
-            text_.add_line("void " + name + "(int i_, value_type weight) {");
+            // Override `deliver_events`.
+            text_.add_line("void deliver_events(multi_event_stream& events) override {");
             text_.increase_indentation();
-            text_.add_line(
-                "kernels::" + name + "<value_type, size_type>"
-                + "<<<1, 1>>>(param_pack_, i_, weight);");
+            text_.add_line("auto ncell = events.n_streams();");
+            text_.add_line("constexpr int blockwidth = 128;");
+            text_.add_line("int nblock = 1+(ncell-1)/blockwidth;");
+            text_.add_line("kernels::deliver_events<value_type, size_type>"
+                           "<<<nblock, blockwidth>>>(param_pack_, mech_id_, events.delivery_data());");
+            text_.decrease_indentation();
+            text_.add_line("}");
+            text_.add_line();
+
+            // Provide testing interface to `net_receive`.
+            text_.add_line("void net_receive(int i_, value_type weight) override {");
+            text_.increase_indentation();
+            text_.add_line("kernels::net_receive_global<value_type, size_type>"
+                           "<<<1, 1>>>(param_pack_, i_, weight);");
             text_.decrease_indentation();
             text_.add_line("}");
             text_.add_line();
@@ -471,6 +482,7 @@ CUDAPrinter::CUDAPrinter(Module &m, bool o)
         }
     }
 
+    text_.add_line("using base::mech_id_;");
     text_.add_line("using base::vec_ci_;");
     text_.add_line("using base::vec_t_;");
     text_.add_line("using base::vec_t_to_;");
@@ -694,10 +706,11 @@ void CUDAPrinter::visit(ProcedureExpression *e) {
     }
     else {
         // net_receive() kernel is a special case, not covered by APIMethod visit.
+
+        // Core `net_receive` kernel is called device-side from `kernel::deliver_events`.
         text_.add_gutter() << "template <typename T, typename I>\n";
-        text_.add_line(       "__global__");
-        text_.add_gutter() << "void " << e->name()
-                           << "(" << module_->name() << "_ParamPack<T,I> params_, "
+        text_.add_line(       "__device__");
+        text_.add_gutter() << "void net_receive(const " << module_->name() << "_ParamPack<T,I>& params_, "
                            << "I i_, T weight) {";
         text_.add_line();
         increase_indentation();
@@ -706,12 +719,56 @@ void CUDAPrinter::visit(ProcedureExpression *e) {
         text_.add_line("using iarray = I;");
         text_.add_line();
 
-        text_.add_line("if (threadIdx.x || blockIdx.x) return;");
         text_.add_line("auto tid_ = i_;");
         text_.add_line("auto gid_ __attribute__((unused)) = params_.ni[tid_];");
         text_.add_line("auto cid_ __attribute__((unused)) = params_.ci[gid_];");
 
         print_APIMethod_body(e);
+
+        decrease_indentation();
+        text_.add_line("}");
+        text_.add_line();
+
+        // Global one-thread wrapper for `net_receive` kernel is used to implement the
+        // `mechanism::net_receive` method. This is not called in the normal course
+        // of event delivery.
+        text_.add_gutter() << "template <typename T, typename I>\n";
+        text_.add_line(       "__global__");
+        text_.add_gutter() << "void net_receive_global("
+                           << module_->name() << "_ParamPack<T,I> params_, "
+                           << "I i_, T weight) {";
+        text_.add_line();
+        increase_indentation();
+
+        text_.add_line("if (threadIdx.x || blockIdx.x) return;");
+        text_.add_line("net_receive<T, I>(params_, i_, weight);");
+
+        decrease_indentation();
+        text_.add_line("}");
+        text_.add_line();
+
+        text_.add_gutter() << "template <typename T, typename I>\n";
+        text_.add_line(       "__global__");
+        text_.add_gutter() << "void deliver_events("
+                           << module_->name() << "_ParamPack<T,I> params_, "
+                           << "I mech_id, multi_event_stream::span_state state) {";
+        text_.add_line();
+        increase_indentation();
+
+        text_.add_line("auto tid_ = threadIdx.x + blockDim.x*blockIdx.x;");
+        text_.add_line("auto const ncell_ = state.n;");
+        text_.add_line();
+        text_.add_line("if(tid_<ncell_) {");
+        increase_indentation();
+
+        text_.add_line("for (auto j = state.span_begin[tid_]; j<state.mark[tid_]; ++j) {");
+        increase_indentation();
+        text_.add_line("if (state.ev_mech_id[j]==mech_id) net_receive<T, I>(params_, state.ev_index[j], state.ev_weight[j]);");
+        decrease_indentation();
+        text_.add_line("}");
+
+        decrease_indentation();
+        text_.add_line("}");
 
         decrease_indentation();
         text_.add_line("}");

--- a/modcc/cudaprinter.cpp
+++ b/modcc/cudaprinter.cpp
@@ -189,7 +189,7 @@ CUDAPrinter::CUDAPrinter(Module &m, bool o)
 
     int num_vars = array_variables.size();
     text_.add_line();
-    text_.add_line(class_name + "(value_type mech_id, const_iview vec_ci, const_view vec_t, const_view vec_t_to, view vec_v, view vec_i, array&& weights, iarray&& node_index):");
+    text_.add_line(class_name + "(size_type mech_id, const_iview vec_ci, const_view vec_t, const_view vec_t_to, view vec_v, view vec_i, array&& weights, iarray&& node_index):");
     text_.add_line("   base(mech_id, vec_ci, vec_t, vec_t_to, vec_v, vec_i, std::move(node_index))");
     text_.add_line("{");
     text_.increase_indentation();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ set(BASE_SOURCES
 )
 set(CUDA_SOURCES
     backends/gpu/fvm.cu
+    backends/gpu/multi_event_stream.cu
     memory/fill.cu
 )
 

--- a/src/backends/event.hpp
+++ b/src/backends/event.hpp
@@ -11,7 +11,7 @@ namespace mc {
 struct target_handle {
     cell_local_size_type mech_id;    // mechanism type identifier (per cell group).
     cell_local_size_type index;      // instance of the mechanism
-    cell_size_type cell_index; // which cell (acts as index into e.g. vec_t)
+    cell_size_type cell_index;       // which cell (acts as index into e.g. vec_t)
 
     target_handle() {}
     target_handle(cell_local_size_type mech_id, cell_local_size_type index, cell_size_type cell_index):

--- a/src/backends/gpu/fvm.hpp
+++ b/src/backends/gpu/fvm.hpp
@@ -112,7 +112,7 @@ struct backend {
     }
 
 private:
-    using maker_type = mechanism (*)(value_type, const_iview, const_view, const_view, view, view, array&&, iarray&&);
+    using maker_type = mechanism (*)(size_type, const_iview, const_view, const_view, view, view, array&&, iarray&&);
     static std::map<std::string, maker_type> mech_map_;
 
     template <template <typename> class Mech>

--- a/src/backends/gpu/fvm.hpp
+++ b/src/backends/gpu/fvm.hpp
@@ -62,7 +62,7 @@ struct backend {
 
     static mechanism make_mechanism(
         const std::string& name,
-        value_type mech_id,
+        size_type mech_id,
         const_iview vec_ci,
         const_view vec_t, const_view vec_t_to,
         view vec_v, view vec_i,
@@ -103,7 +103,6 @@ struct backend {
 
         // return gpu::any_time_before(t.size(), t.data(), t_test);
 
-        cudaDeviceSynchronize();
         auto v_copy = memory::on_host(t);
         return util::minmax_value(v_copy).first<t_test;
     }
@@ -117,7 +116,7 @@ private:
     static std::map<std::string, maker_type> mech_map_;
 
     template <template <typename> class Mech>
-    static mechanism maker(value_type mech_id, const_iview vec_ci, const_view vec_t, const_view vec_t_to, view vec_v, view vec_i, array&& weights, iarray&& node_indices) {
+    static mechanism maker(size_type mech_id, const_iview vec_ci, const_view vec_t, const_view vec_t_to, view vec_v, view vec_i, array&& weights, iarray&& node_indices) {
         return mechanisms::make_mechanism<Mech<backend>>
             (mech_id, vec_ci, vec_t, vec_t_to, vec_v, vec_i, std::move(weights), std::move(node_indices));
     }

--- a/src/backends/gpu/kernels/assemble_matrix.hpp
+++ b/src/backends/gpu/kernels/assemble_matrix.hpp
@@ -32,14 +32,24 @@ void assemble_matrix_flat(
         auto cid = cv_to_cell[tid];
         auto dt = t_to[cid] - t[cid];
 
-        // The 1e-3 is a constant of proportionality required to ensure that the
-        // conductance (gi) values have units μS (micro-Siemens).
-        // See the model documentation in docs/model for more information.
-        T factor = 1e-3/dt;
+        // Note: dt==0 case is expected only at the end of a mindelay/2
+        // integration period, and consequently divergence is unlikely
+        // to be a peformance problem.
 
-        auto gi = factor * cv_capacitance[tid];
-        d[tid] = gi + invariant_d[tid];
-        rhs[tid] = gi*voltage[tid] - current[tid];
+        if (dt>0) {
+            // The 1e-3 is a constant of proportionality required to ensure that the
+            // conductance (gi) values have units μS (micro-Siemens).
+            // See the model documentation in docs/model for more information.
+            T factor = 1e-3/dt;
+
+            auto gi = factor * cv_capacitance[tid];
+            d[tid] = gi + invariant_d[tid];
+            rhs[tid] = gi*voltage[tid] - current[tid];
+        }
+        else {
+            d[tid] = 0;
+            rhs[tid] = voltage[tid];
+        }
     }
 }
 
@@ -91,17 +101,18 @@ void assemble_matrix_interleaved(
     const unsigned max_size = sizes[0];
 
     T factor = 0;
+    T dt = 0;
     const unsigned permuted_cid = blk_id*BlockWidth + blk_lane;
 
     if (permuted_cid<num_mtx) {
         auto cid = matrix_to_cell[permuted_cid];
-        T dt = time_to[cid]-time[cid];
+        dt = time_to[cid]-time[cid];
 
         // The 1e-3 is a constant of proportionality required to ensure that the
         // conductance (gi) values have units μS (micro-Siemens).
         // See the model documentation in docs/model for more information.
 
-        factor = 1e-3/dt;
+        factor = dt>0? 1e-3/dt: 0;
     }
 
     for (unsigned j=0u; j<max_size; j+=LoadWidth) {
@@ -114,9 +125,18 @@ void assemble_matrix_interleaved(
 
         if (j+blk_row<padded_size) {
             const auto gi = factor * cv_capacitance[store_pos];
-            d[store_pos]   = gi + invariant_d[store_pos];
-            rhs[store_pos] = gi*buffer_v[blk_pos] - buffer_i[blk_pos];
+
+            if (dt>0) {
+                d[store_pos]   = (gi + invariant_d[store_pos]);
+                rhs[store_pos] = (gi*buffer_v[blk_pos] - buffer_i[blk_pos]);
+            }
+            else {
+                d[store_pos]   = 0;
+                rhs[store_pos] = buffer_v[blk_pos];
+            }
         }
+
+        __syncthreads();
 
         store_pos += LoadWidth*BlockWidth;
         load_pos  += LoadWidth;

--- a/src/backends/gpu/kernels/interleave.hpp
+++ b/src/backends/gpu/kernels/interleave.hpp
@@ -55,6 +55,7 @@ void flat_to_interleaved(
         if (i+blk_row<padded_size) {
             out[store_pos] = buffer[blk_pos];
         }
+        __syncthreads();
         load_pos  += LoadWidth;
         store_pos += LoadWidth*BlockWidth;
     }
@@ -100,6 +101,7 @@ void interleaved_to_flat(
         if (do_store && store_pos<end) {
             out[store_pos] = buffer[lid];
         }
+        __syncthreads();
         load_pos  += LoadWidth*BlockWidth;
         store_pos += LoadWidth;
     }

--- a/src/backends/gpu/kernels/solve_matrix.hpp
+++ b/src/backends/gpu/kernels/solve_matrix.hpp
@@ -20,8 +20,12 @@ void solve_matrix_flat(
         const auto first = cell_cv_divs[tid];
         const auto last  = cell_cv_divs[tid+1];
 
+        // Zero diagonal term implies dt==0; just leave rhs (for whole matrix)
+        // alone in that case.
+        if (d[last-1]==0) return;
+
         // backward sweep
-        for(auto i=last-1; i>first; --i) {
+        for (auto i=last-1; i>first; --i) {
             auto factor = u[i] / d[i];
             d[p[i]]   -= factor * u[i];
             rhs[p[i]] -= factor * rhs[i];
@@ -54,6 +58,10 @@ void solve_matrix_interleaved(
         const auto first    = block_start*padded_size + block_lane;
         const auto last     = first + BlockWidth*(sizes[tid]-1);
         const auto last_max = first + BlockWidth*(sizes[block_start]-1);
+
+        // Zero diagonal term implies dt==0; just leave rhs (for whole matrix)
+        // alone in that case.
+        if (d[last]==0) return;
 
         // backward sweep
         for(auto i=last_max; i>first; i-=BlockWidth) {

--- a/src/backends/gpu/kernels/time_ops.hpp
+++ b/src/backends/gpu/kernels/time_ops.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <type_traits>
+
+#include <cuda.h>
+
+#include <memory/wrappers.hpp>
+
+namespace nest {
+namespace mc {
+namespace gpu {
+
+namespace kernels {
+    template <typename T, typename I>
+    __global__ void update_time_to(I n, T* time_to, const T* time, T dt, T tmax) {
+        int i = threadIdx.x+blockIdx.x*blockDim.x;
+        if (i>=n) return;
+
+        auto t = time[i]+dt;
+        time_to[i] = t<tmax? t: tmax;
+    }
+
+    // array-array comparison
+    template <typename T, typename I, typename Pred>
+    __global__ void array_reduce_any(I n, const T* x, const T* y, Pred p, int* rptr) {
+        int i = threadIdx.x+blockIdx.x*blockDim.x;
+        int cmp = i<n? p(x[i], y[i]): 0;
+        if (__syncthreads_or(cmp)) *rptr=1;
+    }
+
+    // array-scalar comparison
+    template <typename T, typename I, typename Pred>
+    __global__ void array_reduce_any(I n, const T* x, T y, Pred p, int* rptr) {
+        int i = threadIdx.x+blockIdx.x*blockDim.x;
+        int cmp = i<n? p(x[i], y): 0;
+        if (__syncthreads_or(cmp)) *rptr=1;
+    }
+
+    template <typename T>
+    struct less {
+        __device__ __host__
+        bool operator()(const T& a, const T& b) const { return a<b; }
+    };
+}
+
+template <typename T, typename I>
+void update_time_to(I n, T* time_to, const T* time, T dt, T tmax) {
+    if (!n) return;
+
+    constexpr int blockwidth = 128;
+    int nblock = 1+(n-1)/blockwidth;
+    kernels::update_time_to<<<nblock, blockwidth>>>(n, time_to, time, dt, tmax);
+}
+
+template <typename T, typename U, typename I>
+bool any_time_before(I n, T* t0, U t1) {
+    static_assert(std::is_convertible<T*, U>::value || std::is_convertible<T, U>::value,
+        "third-argument must be a compatible scalar or pointer type");
+
+    static thread_local auto r = memory::device_vector<int>(1);
+    if (!n) return false;
+
+    constexpr int blockwidth = 128;
+    int nblock = 1+(n-1)/blockwidth;
+
+    r[0] = 0;
+    kernels::array_reduce_any<<<nblock, blockwidth>>>(n, t0, t1, kernels::less<T>(), r.data());
+    //cudaDeviceSynchronize();
+    return r[0];
+}
+
+} // namespace gpu
+} // namespace mc
+} // namespace nest

--- a/src/backends/gpu/matrix_state_flat.hpp
+++ b/src/backends/gpu/matrix_state_flat.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory/memory.hpp>
+#include <memory/wrappers.hpp>
 #include <util/span.hpp>
 #include <util/partition.hpp>
 #include <util/rangeutil.hpp>
@@ -38,9 +39,6 @@ struct matrix_state_flat {
     // the invariant part of the matrix diagonal
     array invariant_d;         // [μS]
 
-    // interface for exposing the solution to the outside world
-    view solution;
-
     matrix_state_flat() = default;
 
     matrix_state_flat(const std::vector<size_type>& p,
@@ -58,7 +56,7 @@ struct matrix_state_flat {
         EXPECTS(cv_cap.size() == size());
         EXPECTS(face_cond.size() == size());
         EXPECTS(cell_cv_divs.back() == size());
-        EXPECTS(cell_cv_divs.size() > 2u);
+        EXPECTS(cell_cv_divs.size() > 1u);
 
         using memory::make_const_view;
 
@@ -84,8 +82,11 @@ struct matrix_state_flat {
         cv_to_cell = make_const_view(cv_to_cell_tmp);
         invariant_d = make_const_view(invariant_d_tmp);
         u = make_const_view(u_tmp);
+    }
 
-        solution = rhs;
+    // interface for exposing the solution to the outside world
+    view solution() const {
+        return memory::make_view(rhs);
     }
 
     // Assemble the matrix

--- a/src/backends/gpu/matrix_state_flat.hpp
+++ b/src/backends/gpu/matrix_state_flat.hpp
@@ -85,7 +85,7 @@ struct matrix_state_flat {
     }
 
     // interface for exposing the solution to the outside world
-    view solution() const {
+    const_view solution() const {
         return memory::make_view(rhs);
     }
 

--- a/src/backends/gpu/matrix_state_interleaved.hpp
+++ b/src/backends/gpu/matrix_state_interleaved.hpp
@@ -81,7 +81,7 @@ struct matrix_state_interleaved {
     //  Storage for solution in uninterleaved format.
     //  Used to hold the storage for passing to caller, and must be updated
     //  after each call to the ::solve() method.
-    array solution;
+    array solution_;
 
     // default constructor
     matrix_state_interleaved() = default;
@@ -200,7 +200,11 @@ struct matrix_state_interleaved {
         matrix_to_cell_index = memory::make_const_view(perm);
 
         // Allocate space for storing the un-interleaved solution.
-        solution = array(p.size());
+        solution_ = array(p.size());
+    }
+
+    const_view solution() const {
+        return solution_;
     }
 
     // Assemble the matrix
@@ -238,7 +242,7 @@ struct matrix_state_interleaved {
 
         // Copy the solution from interleaved to front end storage.
         interleaved_to_flat<value_type, size_type, impl::block_dim(), impl::load_width()>
-            (rhs.data(), solution.data(), matrix_sizes.data(), matrix_index.data(),
+            (rhs.data(), solution_.data(), matrix_sizes.data(), matrix_index.data(),
              padded_matrix_size(), num_matrices());
     }
 

--- a/src/backends/gpu/multi_event_stream.cu
+++ b/src/backends/gpu/multi_event_stream.cu
@@ -1,0 +1,156 @@
+#include <common_types.hpp>
+#include <backends/event.hpp>
+#include <backends/gpu/multi_event_stream.hpp>
+#include <memory/array.hpp>
+#include <memory/copy.hpp>
+#include <util/rangeutil.hpp>
+
+namespace nest {
+namespace mc {
+namespace gpu {
+
+namespace kernel {
+    template <typename T, typename I>
+    __global__ void mark_until_after(
+        I n,
+        I* mark,
+        const I* span_end,
+        const T* ev_time,
+        const T* t_until)
+    {
+        I i = threadIdx.x+blockIdx.x*blockDim.x;
+        if (i>=n) return;
+
+        auto t = t_until[i];
+        auto end = span_end[i];
+        auto &m = mark[i];
+
+        while (m!=end && !(ev_time[m]>t)) { ++m; }
+    }
+
+    template <typename T, typename I>
+    __global__ void drop_marked_events(
+        I n,
+        I* n_nonempty,
+        I* span_begin,
+        const I* span_end,
+        const I* mark)
+    {
+        I i = threadIdx.x+blockIdx.x*blockDim.x;
+        if (i>=n) return;
+
+        bool emptied = (span_begin[i]<span_end[i] && mark[i]==span_end[i]);
+        span_begin[i] = mark[i];
+        if (emptied) {
+            atomicAdd(n_nonempty, (cell_size_type)-1);
+        }
+    }
+
+    template <typename T, typename I>
+    __global__ void event_time_if_before(
+        I n,
+        const I* span_begin,
+        const I* span_end,
+        const T* ev_time,
+        T* t_until)
+    {
+        I i = threadIdx.x+blockIdx.x*blockDim.x;
+        if (i>=n) return;
+
+        if (span_begin[i]<span_end[i]) {
+            auto ev_t = ev_time[span_begin[i]];
+            if (t_until[i]>ev_t) {
+                t_until[i] = ev_t;
+            }
+        }
+    }
+} // namespace kernel
+
+void multi_event_stream::clear() {
+    memory::fill(span_begin_, 0u);
+    memory::fill(span_end_, 0u);
+    memory::fill(mark_, 0u);
+    n_nonempty_stream_[0] = 0;
+}
+
+void multi_event_stream::init(const std::vector<deliverable_event>& staged) {
+    if (staged.size()>std::numeric_limits<size_type>::max()) {
+        throw std::range_error("too many events");
+    }
+
+    // Build vectors in host memory here and transfer to the device at end.
+    std::vector<deliverable_event> ev(staged);
+    std::size_t n_ev = ev.size();
+
+    std::vector<size_type> divisions(n_stream_+1, 0);
+    std::vector<size_type> tmp_ev_indices(n_ev);
+    std::vector<value_type> tmp_ev_values(n_ev);
+
+    ev_time_ = array(n_ev);
+    ev_weight_ = array(n_ev);
+    ev_mech_id_ = iarray(n_ev);
+    ev_index_ = iarray(n_ev);
+
+    util::stable_sort_by(ev, [](const deliverable_event& e) { return e.handle.cell_index; });
+
+    // Split out event fields and copy to device.
+    util::assign_by(tmp_ev_values, ev, [](const deliverable_event& e) { return e.weight; });
+    memory::copy(tmp_ev_values, ev_weight_);
+
+    util::assign_by(tmp_ev_values, ev, [](const deliverable_event& e) { return e.time; });
+    memory::copy(tmp_ev_values, ev_time_);
+
+    util::assign_by(tmp_ev_indices, ev, [](const deliverable_event& e) { return e.handle.mech_id; });
+    memory::copy(tmp_ev_indices, ev_mech_id_);
+
+    util::assign_by(tmp_ev_indices, ev, [](const deliverable_event& e) { return e.handle.index; });
+    memory::copy(tmp_ev_indices, ev_index_);
+
+    // Determine divisions by `cell_index` in ev list and copy to device.
+    size_type ev_i = 0;
+    size_type n_nonempty = 0;
+    for (size_type s = 1; s<=n_stream_; ++s) {
+        while (ev_i<n_ev && ev[ev_i].handle.cell_index<s) ++ev_i;
+        divisions[s] = ev_i;
+        n_nonempty += (divisions[s]!=divisions[s-1]);
+    }
+
+    memory::copy(memory::make_view(divisions)(0,n_stream_), span_begin_);
+    memory::copy(memory::make_view(divisions)(1,n_stream_+1), span_end_);
+    memory::copy(span_begin_, mark_);
+    n_nonempty_stream_[0] = n_nonempty;
+}
+
+
+// Designate for processing events `ev` at head of each event stream `i`
+// until `event_time(ev)` > `t_until[i]`.
+void multi_event_stream::mark_until_after(const_view t_until) {
+    EXPECTS(n_streams()==util::size(t_until));
+
+    constexpr int blockwidth = 128;
+    int nblock = 1+(n_stream_-1)/blockwidth;
+    kernel::mark_until_after<value_type, size_type><<<nblock, blockwidth>>>(
+        n_stream_, mark_.data(), span_end_.data(), ev_time_.data(), t_until.data());
+}
+
+// Remove marked events from front of each event stream.
+void multi_event_stream::drop_marked_events() {
+    constexpr int blockwidth = 128;
+    int nblock = 1+(n_stream_-1)/blockwidth;
+    kernel::drop_marked_events<value_type, size_type><<<nblock, blockwidth>>>(
+        n_stream_, n_nonempty_stream_.data(), span_begin_.data(), span_end_.data(), mark_.data());
+}
+
+// If the head of `i`th event stream exists and has time less than `t_until[i]`, set
+// `t_until[i]` to the event time.
+void multi_event_stream::event_time_if_before(view t_until) {
+    constexpr int blockwidth = 128;
+    int nblock = 1+(n_stream_-1)/blockwidth;
+    kernel::event_time_if_before<value_type, size_type><<<nblock, blockwidth>>>(
+        n_stream_, span_begin_.data(), span_end_.data(), ev_time_.data(), t_until.data());
+}
+
+
+} // namespace gpu
+} // namespace nest
+} // namespace mc

--- a/src/backends/gpu/multi_event_stream.hpp
+++ b/src/backends/gpu/multi_event_stream.hpp
@@ -39,7 +39,7 @@ public:
     void clear();
 
     // Initialize event streams from a vector of `deliverable_event`.
-    void init(const std::vector<deliverable_event>& staged);
+    void init(std::vector<deliverable_event> staged);
 
     // Designate for processing events `ev` at head of each event stream `i`
     // until `event_time(ev)` > `t_until[i]`.

--- a/src/backends/gpu/multi_event_stream.hpp
+++ b/src/backends/gpu/multi_event_stream.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+// Indexed collection of pop-only event queues --- multicore back-end implementation.
+
+#include <common_types.hpp>
+#include <backends/event.hpp>
+#include <memory/array.hpp>
+#include <memory/copy.hpp>
+
+namespace nest {
+namespace mc {
+namespace gpu {
+
+class multi_event_stream {
+public:
+    using size_type = cell_size_type;
+    using value_type = double;
+
+    using array = memory::device_vector<value_type>;
+    using iarray = memory::device_vector<size_type>;
+
+    using const_view = array::const_view_type;
+    using view = array::view_type;
+
+    multi_event_stream() {}
+
+    explicit multi_event_stream(size_type n_stream):
+        n_stream_(n_stream),
+        span_begin_(n_stream),
+        span_end_(n_stream),
+        mark_(n_stream),
+        n_nonempty_stream_(1)
+    {}
+
+    size_type n_streams() const { return n_stream_; }
+
+    bool empty() const { return n_nonempty_stream_[0]==0; }
+
+    void clear();
+
+    // Initialize event streams from a vector of `deliverable_event`.
+    void init(const std::vector<deliverable_event>& staged);
+
+    // Designate for processing events `ev` at head of each event stream `i`
+    // until `event_time(ev)` > `t_until[i]`.
+    void mark_until_after(const_view t_until);
+
+    // Remove marked events from front of each event stream.
+    void drop_marked_events();
+
+    // If the head of `i`th event stream exists and has time less than `t_until[i]`, set
+    // `t_until[i]` to the event time.
+    void event_time_if_before(view t_until);
+
+    // Interface for access by mechanism kernels:
+    struct span_state {
+        size_type n;
+        const size_type* ev_mech_id;
+        const size_type* ev_index;
+        const value_type* ev_weight;
+        const size_type* span_begin;
+        const size_type* mark;
+    };
+
+    span_state delivery_data() const {
+        return {n_stream_, ev_mech_id_.data(), ev_index_.data(), ev_weight_.data(), span_begin_.data(), mark_.data()};
+    }
+
+private:
+    size_type n_stream_;
+    array ev_time_;
+    array ev_weight_;
+    iarray ev_mech_id_;
+    iarray ev_index_;
+    iarray span_begin_;
+    iarray span_end_;
+    iarray mark_;
+    iarray n_nonempty_stream_;
+};
+
+} // namespace gpu
+} // namespace nest
+} // namespace mc

--- a/src/backends/gpu/stimulus.hpp
+++ b/src/backends/gpu/stimulus.hpp
@@ -52,8 +52,10 @@ public:
     using const_iview = typename base::const_iview;
     using ion_type = typename base::ion_type;
 
+    static constexpr size_type no_mech_id = (size_type)-1;
+
     stimulus(const_iview vec_ci, const_view vec_t, const_view vec_t_to, view vec_v, view vec_i, iarray&& node_index):
-        base(vec_ci, vec_t, vec_t_to, vec_v, vec_i, std::move(node_index))
+        base(no_mech_id, vec_ci, vec_t, vec_t_to, vec_v, vec_i, std::move(node_index))
     {}
 
     using base::size;

--- a/src/backends/multicore/fvm.hpp
+++ b/src/backends/multicore/fvm.hpp
@@ -95,6 +95,12 @@ struct backend {
         return util::minmax_value(v);
     }
 
+    // perform element-wise comparison on 'array' type against `t_test`.
+    template <typename V>
+    static bool any_time_before(const memory::host_vector<V>& t, V t_test) {
+        return minmax_value(t).first<t_test;
+    }
+
     static void update_time_to(array& time_to, const_view time, value_type dt, value_type tmax) {
         size_type ncell = util::size(time);
         for (size_type i = 0; i<ncell; ++i) {

--- a/src/backends/multicore/fvm.hpp
+++ b/src/backends/multicore/fvm.hpp
@@ -90,7 +90,8 @@ struct backend {
 
 
     // perform min/max reductions on 'array' type
-    static std::pair<value_type, value_type> minmax_value(const array& v) {
+    template <typename V>
+    static std::pair<V, V> minmax_value(const memory::host_vector<V>& v) {
         return util::minmax_value(v);
     }
 

--- a/src/backends/multicore/matrix_state.hpp
+++ b/src/backends/multicore/matrix_state.hpp
@@ -30,8 +30,6 @@ public:
     // the invariant part of the matrix diagonal
     array invariant_d;         // [μS]
 
-    const_view solution;
-
     matrix_state() = default;
 
     matrix_state(const std::vector<size_type>& p,
@@ -57,11 +55,14 @@ public:
             invariant_d[i] += gij;
             invariant_d[p[i]] += gij;
         }
+    }
 
+    const_view solution() const {
         // In this back end the solution is a simple view of the rhs, which
         // contains the solution after the matrix_solve is performed.
-        solution = rhs;
+        return const_view(rhs);
     }
+
 
     // Assemble the matrix
     // Afterwards the diagonal and RHS will have been set given dt, voltage and current
@@ -101,7 +102,7 @@ public:
             auto first = cv_span.first;
             auto last = cv_span.second; // one past the end
 
-            if (d[first]>0) {
+            if (d[first]!=0) {
                 // backward sweep
                 for(auto i=last-1; i>first; --i) {
                     auto factor = u[i] / d[i];

--- a/src/backends/multicore/multi_event_stream.hpp
+++ b/src/backends/multicore/multi_event_stream.hpp
@@ -10,6 +10,7 @@
 #include <backends/event.hpp>
 #include <util/debug.hpp>
 #include <util/range.hpp>
+#include <util/rangeutil.hpp>
 #include <util/strprintf.hpp>
 
 namespace nest {
@@ -19,6 +20,7 @@ namespace multicore {
 class multi_event_stream {
 public:
     using size_type = cell_size_type;
+    using value_type = double;
 
     multi_event_stream() {}
 
@@ -43,13 +45,11 @@ public:
             throw std::range_error("too many events");
         }
 
-        ev_.resize(staged.size());
-        std::copy(staged.begin(), staged.end(), ev_.begin());
+        ev_ = staged;
+        util::stable_sort_by(ev_, [](const deliverable_event& e) { return e.handle.cell_index; });
 
         util::fill(span_, span_type(0u, 0u));
         util::fill(mark_, 0u);
-
-        util::stable_sort_by(ev_, [](const deliverable_event& e) { return e.handle.cell_index; });
 
         size_type si = 0;
         for (size_type ev_i = 0; ev_i<ev_.size(); ++ev_i) {
@@ -129,10 +129,6 @@ public:
         }
     }
 
-    // TODO: remove once we are confident implementation of lowered cell event delivery
-    // is sound.
-    friend std::ostream& operator<<(std::ostream& out, const multi_event_stream& m);
-
 private:
     using span_type = std::pair<size_type, size_type>;
 
@@ -141,40 +137,6 @@ private:
     std::vector<size_type> mark_;
     size_type remaining_ = 0;
 };
-
-inline std::ostream& operator<<(std::ostream& out, const multi_event_stream& m) {
-    auto n = m.n_streams();
-
-    out << "\n[";
-    unsigned i = 0;
-    for (unsigned ev_i = 0; ev_i<m.ev_.size(); ++ev_i) {
-        while (m.span_[i].second<=ev_i && i<n) ++i;
-        if (i<n) {
-            out << util::strprintf(" % 7d ", i);
-        }
-        else {
-            out << "      ?";
-        }
-    }
-    out << "\n[";
-
-    i = 0;
-    for (unsigned ev_i = 0; ev_i<m.ev_.size(); ++ev_i) {
-        while (m.span_[i].second<=ev_i && i<n) ++i;
-
-        bool discarded = i<n && m.span_[i].first>ev_i;
-        bool marked = i<n && m.mark_[i]>ev_i;
-
-        if (discarded) {
-            out << "        x";
-        }
-        else {
-            out << util::strprintf(" % 7.3f%c", m.ev_[ev_i].time, marked?'*':' ');
-        }
-    }
-    out << "]\n";
-    return out;
-}
 
 } // namespace multicore
 } // namespace nest

--- a/src/backends/multicore/multi_event_stream.hpp
+++ b/src/backends/multicore/multi_event_stream.hpp
@@ -40,12 +40,12 @@ public:
     }
 
     // Initialize event streams from a vector of `deliverable_event`.
-    void init(const std::vector<deliverable_event>& staged) {
+    void init(std::vector<deliverable_event> staged) {
         if (staged.size()>std::numeric_limits<size_type>::max()) {
             throw std::range_error("too many events");
         }
 
-        ev_ = staged;
+        ev_ = std::move(staged);
         util::stable_sort_by(ev_, [](const deliverable_event& e) { return e.handle.cell_index; });
 
         util::fill(span_, span_type(0u, 0u));

--- a/src/fvm_multicell.hpp
+++ b/src/fvm_multicell.hpp
@@ -97,7 +97,7 @@ public:
 
         EXPECTS(!has_pending_events());
 
-        events_->init(staged_events_);
+        events_->init(std::move(staged_events_));
         staged_events_.clear();
     }
 
@@ -298,13 +298,13 @@ private:
     // Maintain cached copy of time vector for querying by
     // cell_group. This will no longer be necessary when full
     // integration loop is in lowered cell.
-    mutable std::vector<time_type> cached_time_;
+    mutable std::vector<value_type> cached_time_;
     mutable bool cached_time_valid_ = false;
 
     void invalidate_time_cache() { cached_time_valid_ = false; }
     void refresh_time_cache() const {
         if (!cached_time_valid_) {
-            util::assign(cached_time_, memory::on_host(time_));
+            memory::copy(time_, memory::make_view(cached_time_));
         }
         cached_time_valid_ = true;
     }
@@ -535,6 +535,8 @@ void fvm_multicell<Backend>::initialize(
     cv_to_cell_ = iarray(ncomp, 0);
     time_ = array(ncell_, 0);
     time_to_ = array(ncell_, 0);
+    cached_time_.resize(ncell_);
+    cached_time_valid_ = false;
 
     // initialize cv_to_cell_ values from compartment partition
     std::vector<size_type> cv_to_cell_tmp(ncomp);

--- a/src/matrix.hpp
+++ b/src/matrix.hpp
@@ -36,10 +36,10 @@ public:
 
     matrix() = default;
 
-    matrix( const std::vector<size_type>& pi,
-            const std::vector<size_type>& ci,
-            const std::vector<value_type>& cv_capacitance,
-            const std::vector<value_type>& face_conductance):
+    matrix(const std::vector<size_type>& pi,
+           const std::vector<size_type>& ci,
+           const std::vector<value_type>& cv_capacitance,
+           const std::vector<value_type>& face_conductance):
         parent_index_(memory::make_const_view(pi)),
         cell_index_(memory::make_const_view(ci)),
         state_(pi, ci, cv_capacitance, face_conductance)
@@ -75,11 +75,10 @@ public:
 
     /// Get a view of the solution
     const_view solution() const {
-        return state_.solution;
+        return state_.solution();
     }
 
-    private:
-
+private:
     /// the parent indice that describe matrix structure
     iarray parent_index_;
 

--- a/src/mechanism.hpp
+++ b/src/mechanism.hpp
@@ -65,12 +65,14 @@ public:
     virtual void nrn_init()     = 0;
     virtual void nrn_state()    = 0;
     virtual void nrn_current()  = 0;
-    virtual void net_receive(int, value_type) {};
     virtual void deliver_events(multi_event_stream& events) {};
     virtual bool uses_ion(ionKind) const = 0;
     virtual void set_ion(ionKind k, ion_type& i, const std::vector<size_type>& index) = 0;
-
     virtual mechanismKind kind() const = 0;
+
+    // net_receive() is used internally by deliver_events(), but
+    // is exposed primarily for unit testing.
+    virtual void net_receive(int, value_type) {};
 
     virtual ~mechanism() = default;
 

--- a/src/mechanism.hpp
+++ b/src/mechanism.hpp
@@ -39,6 +39,8 @@ public:
 
     using ion_type = ion<backend>;
 
+    using multi_event_stream = typename backend::multi_event_stream;
+
     mechanism(size_type mech_id, const_iview vec_ci, const_view vec_t, const_view vec_t_to, view vec_v, view vec_i, iarray&& node_index):
         mech_id_(mech_id),
         vec_ci_(vec_ci),
@@ -64,20 +66,9 @@ public:
     virtual void nrn_state()    = 0;
     virtual void nrn_current()  = 0;
     virtual void net_receive(int, value_type) {};
+    virtual void deliver_events(multi_event_stream& events) {};
     virtual bool uses_ion(ionKind) const = 0;
     virtual void set_ion(ionKind k, ion_type& i, const std::vector<size_type>& index) = 0;
-
-    // TODO: virtualize, move to backend
-    void deliver_events(typename backend::multi_event_stream& events) {
-        auto ncell = events.n_streams();
-        for (size_type c = 0; c<ncell; ++c) {
-            for (auto ev: events.marked_events(c)) {
-                if (ev.handle.mech_id == mech_id_) {
-                    net_receive(ev.handle.index, ev.weight);
-                }
-            }
-        }
-    }
 
     virtual mechanismKind kind() const = 0;
 

--- a/src/model.hpp
+++ b/src/model.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
+#include <cstdlib>
 #include <memory>
 #include <vector>
-
-#include <cstdlib>
 
 #include <common_types.hpp>
 #include <cell.hpp>
@@ -121,7 +120,6 @@ public:
         // minimum delay of the network, however we use half this period
         // to overlap communication and computation.
         time_type t_interval = communicator_.min_delay()/2;
-
         time_type tuntil;
 
         // task that updates cell state in parallel.

--- a/src/util/compat.hpp
+++ b/src/util/compat.hpp
@@ -44,5 +44,4 @@ inline void compiler_barrier_if_icc_leq(unsigned ver) {
 template <typename X>
 inline constexpr bool isinf(X x) { return std::isinf(x); }
 
-
 } // namespace compat

--- a/src/util/debug.hpp
+++ b/src/util/debug.hpp
@@ -51,6 +51,7 @@ template <typename... Args>
 void debug_emit_trace(const char* file, int line, const char* varlist, const Args&... args) {
     if (nest::mc::threading::multithreaded()) {
         std::stringstream buffer;
+        buffer.precision(17);
 
         debug_emit_trace_leader(buffer, file, line, varlist);
         debug_emit(buffer, args...);

--- a/tests/ubench/CMakeLists.txt
+++ b/tests/ubench/CMakeLists.txt
@@ -5,6 +5,9 @@ include(ExternalProject)
 set(bench_sources
     accumulate_functor_values.cpp)
 
+set(bench_sources_cuda
+    cuda_compare_and_reduce.cu)
+
 # Set up google benchmark as an external project.
 
 set(gbench_src_dir "${CMAKE_CURRENT_SOURCE_DIR}/google-benchmark")
@@ -61,6 +64,19 @@ foreach(bench_src ${bench_sources})
 
     list(APPEND bench_exe_list ${bench_exe})
 endforeach()
+
+
+if(NMC_WITH_CUDA)
+    foreach(bench_src ${bench_sources_cuda})
+        string(REGEX REPLACE "\\.[^.]*$" "" bench_exe "${bench_src}")
+        cuda_add_executable("${bench_exe}" EXCLUDE_FROM_ALL "${bench_src}")
+        add_dependencies("${bench_exe}" gbench)
+        target_include_directories("${bench_exe}" PRIVATE "${gbench_install_dir}/include")
+        target_link_libraries("${bench_exe}" "${gbench_install_dir}/lib/libbenchmark.a")
+
+        list(APPEND bench_exe_list ${bench_exe})
+    endforeach()
+endif()
 
 add_custom_target(ubenches DEPENDS ${bench_exe_list})
 

--- a/tests/ubench/README.md
+++ b/tests/ubench/README.md
@@ -63,3 +63,60 @@ Platform:
 | g++ -O3     |  907 ns | 2090 ns |  907 ns | 614 ns |
 | clang++ -O3 | 1063 ns |  533 ns | 1051 ns | 532 ns |
 
+---
+
+### `cuda_compare_and_reduce`
+
+#### Motivation
+
+One possible mechanism for determining if device-side event delivery had exhausted all
+events is to see if the start and end of each event-span of each cell were equal or not.
+This is equivalent to the test:
+
+> ∃i: a[i] &lt; b[i]?
+
+for device vectors _a_ and _b_.
+
+How expensive is it simply to copy the vectors over to the host and compare there?
+Benchmarking indicated that for vectors up to approximately 10^5 elements, it was
+significiantly faster to copy to host, despite the limited host–device bandwidth.
+
+This non-intuitive result appears to be the result of the high overhead of `cudaMalloc`;
+pre-allocating space on the device for the reduction result restores expected
+performance behaviour.
+
+#### Implementations
+
+Four implementations are considered:
+
+1. Copy both vectors to host, run short-circuit compare.
+
+2. Use `thrust::zip_iterator` and `thrust::any_of` to run the reduction on the device.
+
+3. Use a short custom cuda kernel to run the reduction, using `__syncthreads_or` and
+   a non-atomic write to the result.
+
+4. Use the same cuda kernel as above, but pre-allocate the device memory to store the
+   result.
+
+Note: a fairer host-based comparison would interleave comparison with data transfer.
+
+#### Results
+
+Results here are presented for vector size _n_ equal to 256, 512, 32768 and 262144,
+with the two vectors equal.
+
+Platform:
+* Xeon(R) CPU E5-2650 v4 with base clock 2.20 GHz and max clock 2.9 GHz.
+* Tesla P100-PCIE-16GB
+* Linux 3.10.0
+* gcc version 5.3.0
+* nvcc version 8.0.61
+
+| _n_ | host copy | thrust | custom cuda | custom cuda noalloc |
+|:----|----------:|-------:|------------:|--------------------:|
+| 256    |  18265 ns |  41221 ns |  23255 ns | 16440 ns |
+| 512    |  18466 ns | 286331 ns | 265113 ns | 16335 ns |
+| 32768  | 102880 ns | 296836 ns | 265169 ns | 16758 ns |
+| 262144 | 661724 ns | 305209 ns | 269095 ns | 19792 ns |
+

--- a/tests/ubench/cuda_compare_and_reduce.cu
+++ b/tests/ubench/cuda_compare_and_reduce.cu
@@ -1,0 +1,203 @@
+/* Compare implementations of the test:
+ *    ∃i: a[i]<b[i]?
+ * for device-side arrays a and b.
+ *
+ * Four implementations are compared:
+ * 1. Copy both vectors to host, compare there.
+ * 2. Use the thrust library.
+ * 3. Use a small custom cuda kernel.
+ * 4. Same custom cuda kernel with once-off allocation of return value.
+ */
+
+// Explicitly undef NDEBUG for assert below.
+#undef NDEBUG
+
+#include <algorithm>
+#include <cassert>
+#include <random>
+#include <vector>
+
+#include <benchmark/benchmark.h>
+
+#include <cuda_profiler_api.h>
+#include <thrust/copy.h>
+#include <thrust/device_ptr.h>
+#include <thrust/device_vector.h>
+#include <thrust/functional.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/logical.h>
+
+template <typename Impl>
+void bench_generic(benchmark::State& state, const Impl& impl) {
+    std::size_t n = state.range(0);
+
+    int oop = state.range(1);
+    double p_inclusion = oop? 1.0/oop: 0;
+
+    // Make device vectors `a` and `b` of size n, and with 
+    // `p_inclusion` chance of `a[i]` < `b[i]` for any given `i`.
+
+    std::bernoulli_distribution B(p_inclusion);
+    std::uniform_int_distribution<int> U(0, 99);
+    std::minstd_rand R;
+
+    std::vector<int> xs(n);
+    std::generate(xs.begin(), xs.end(), [&]() { return U(R); });
+
+    thrust::device_vector<int> a(n);
+    thrust::copy(xs.begin(), xs.end(), a.begin());
+
+    bool differ = false;
+    thrust::device_vector<int> b(n);
+    for (std::size_t i = 0; i<n; ++i) {
+        if (B(R)) {
+            xs[i] += 3;
+            differ = true;
+        }
+    }
+    thrust::copy(xs.begin(), xs.end(), b.begin());
+    cudaDeviceSynchronize();
+
+    // Run benchmark.
+
+    bool result = false;
+    int* aptr = thrust::raw_pointer_cast(a.data());
+    int* bptr = thrust::raw_pointer_cast(b.data());
+
+    cudaProfilerStart();
+    while (state.KeepRunning()) {
+        result = impl(n, aptr, bptr);
+        benchmark::DoNotOptimize(result);
+    }
+    cudaProfilerStop();
+
+    // validate result
+    assert(result==differ);
+}
+
+bool host_copy_compare(std::size_t n, int* aptr, int* bptr) {
+    std::vector<int> a(n);
+    std::vector<int> b(n);
+
+    cudaMemcpy(a.data(), aptr, n*sizeof(int), cudaMemcpyDeviceToHost);
+    cudaMemcpy(b.data(), bptr, n*sizeof(int), cudaMemcpyDeviceToHost);
+
+    for (std::size_t i = 0; i<n; ++i) {
+        if (a[i]<b[i]) return true;
+    }
+    return false;
+}
+
+struct thrust_cmp_pred {
+    __device__
+    bool operator()(const thrust::tuple<int, int>& p) const {
+	return thrust::get<0>(p) < thrust::get<1>(p);
+    }
+};
+
+bool thrust_compare(std::size_t n, int* aptr, int* bptr) {
+    thrust::device_ptr<int> a(aptr), b(bptr);
+
+    auto zip_begin = thrust::make_zip_iterator(thrust::make_tuple(a, b));
+    auto zip_end = thrust::make_zip_iterator(thrust::make_tuple(a+n, b+n));
+
+    return thrust::any_of(zip_begin, zip_end, thrust_cmp_pred{});
+}
+
+__global__ void cuda_cmp_kernel(std::size_t n, int* aptr, int* bptr, int* rptr) {
+    int i = threadIdx.x+blockIdx.x*blockDim.x;
+    int cmp = i<n? aptr[i]<bptr[i]: 0;
+    if (__syncthreads_or(cmp)) *rptr=1;
+}
+
+bool custom_cuda_compare(std::size_t n, int* aptr, int* bptr) {
+    int result;
+
+    constexpr int blockwidth = 128;
+    int nblock = n? 1+(n-1)/blockwidth: 0;
+
+    void* rptr;
+    cudaMalloc(&rptr, sizeof(int));
+    cudaMemset(rptr, 0, sizeof(int));
+    cuda_cmp_kernel<<<nblock, blockwidth>>>(n, aptr, bptr, (int *)rptr);
+    cudaMemcpy(&result, rptr, sizeof(int), cudaMemcpyDeviceToHost);
+    cudaFree(rptr);
+
+    return (bool)result;
+}
+
+template <typename T>
+struct device_store {
+    device_store() {
+	void* p;
+	cudaMalloc(&p, sizeof(T));
+	ptr = (T*)p;
+    }
+
+    ~device_store() { if (ptr) cudaFree(ptr); }
+
+    device_store(const device_store&&) = delete;
+    device_store(device_store&&) = delete;
+
+    T* get() { return ptr; }
+
+private:
+    T* ptr = nullptr;
+};
+
+bool custom_cuda_compare_noalloc(std::size_t n, int* aptr, int* bptr) {
+    static thread_local device_store<int> state;
+    int result;
+
+    constexpr int blockwidth = 128;
+    int nblock = n? 1+(n-1)/blockwidth: 0;
+
+    cudaMemset(state.get(), 0, sizeof(int));
+    cuda_cmp_kernel<<<nblock, blockwidth>>>(n, aptr, bptr, state.get());
+    cudaMemcpy(&result, state.get(), sizeof(int), cudaMemcpyDeviceToHost);
+
+    return (bool)result;
+}
+
+void bench_host_copy_compare(benchmark::State& state) {
+    bench_generic(state, host_copy_compare);
+}
+
+void bench_thrust_compare(benchmark::State& state) {
+    bench_generic(state, thrust_compare);
+}
+
+void bench_custom_cuda_compare(benchmark::State& state) {
+    bench_generic(state, custom_cuda_compare);
+}
+
+void bench_custom_cuda_compare_noalloc(benchmark::State& state) {
+    bench_generic(state, custom_cuda_compare_noalloc);
+}
+
+// Run benches over 256 to circa 1e6 elements, with three cases:
+//
+// Arg1       Values
+// ---------------------------------------------------
+//    0       `a` and `b` equal
+//  200       `a` and `b` differ circa 1 in 200 places.
+//    4       `a` and `b` differ circa 1 in 4 places.
+
+void run_custom_arguments(benchmark::internal::Benchmark* b) {
+    for (int n=1<<8; n<=1<<20; n*=2) {
+        for (int oop: {0, 200, 4}) {
+
+// Uncomment to set fixed iteration count (for e.g. profiling):
+//	    b->Iterations(20);
+
+            b->Args({n, oop});
+        }
+    }
+}
+
+BENCHMARK(bench_host_copy_compare)->Apply(run_custom_arguments);
+BENCHMARK(bench_thrust_compare)->Apply(run_custom_arguments);
+BENCHMARK(bench_custom_cuda_compare)->Apply(run_custom_arguments);
+BENCHMARK(bench_custom_cuda_compare_noalloc)->Apply(run_custom_arguments);
+
+BENCHMARK_MAIN();

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -21,6 +21,7 @@ set(TEST_CUDA_SOURCES
     test_cell_group.cu
     test_gpu_stack.cu
     test_matrix.cu
+    test_multi_event_stream.cu
     test_spikes.cu
     test_vector.cu
 
@@ -47,6 +48,7 @@ set(TEST_SOURCES
     test_math.cpp
     test_matrix.cpp
     test_mechanisms.cpp
+    test_multi_event_stream.cpp
     test_nop.cpp
     test_optional.cpp
     test_parameters.cpp
@@ -106,3 +108,9 @@ foreach(target ${TARGETS})
        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests"
     )
 endforeach()
+
+# Temporary hack (pending PR #266)
+if(NMC_WITH_CUDA)
+    target_link_libraries(test_cuda.exe LINK_PUBLIC nestmc)
+endif()
+

--- a/tests/unit/test_fvm_multi.cpp
+++ b/tests/unit/test_fvm_multi.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <fstream>
 
 #include "../gtest.h"
@@ -5,6 +6,7 @@
 #include <common_types.hpp>
 #include <cell.hpp>
 #include <fvm_multicell.hpp>
+#include <util/meta.hpp>
 #include <util/rangeutil.hpp>
 
 #include "../test_util.hpp"
@@ -321,3 +323,156 @@ TEST(fvm_multi, mechanism_indexes)
         EXPECT_EQ(0u, fvcell.ion_ca().node_index().size());
     }
 }
+
+struct handle_info {
+    unsigned cell;
+    std::string mech;
+    unsigned cv;
+};
+
+// test handle <-> mechanism/index correspondence
+// on a two-cell ball-and-stick system.
+
+void run_target_handle_test(std::vector<handle_info> all_handles) {
+    using namespace nest::mc;
+
+    nest::mc::cell cells[] = {
+        make_cell_ball_and_stick(),
+        make_cell_ball_and_stick()
+    };
+
+    EXPECT_EQ(2u, cells[0].num_segments());
+    EXPECT_EQ(4u, cells[0].segment(1)->num_compartments());
+    EXPECT_EQ(5u, cells[0].num_compartments());
+
+    EXPECT_EQ(2u, cells[1].num_segments());
+    EXPECT_EQ(4u, cells[1].segment(1)->num_compartments());
+    EXPECT_EQ(5u, cells[1].num_compartments());
+
+    std::vector<std::vector<handle_info>> handles(2);
+
+    for (auto x: all_handles) {
+        unsigned seg_id;
+        double pos;
+
+        ASSERT_TRUE(x.cell==0 || x.cell==1);
+        ASSERT_TRUE(x.cv<5);
+        ASSERT_TRUE(x.mech=="expsyn" || x.mech=="exp2syn");
+
+        if (x.cv==0) {
+            // place on soma
+            seg_id = 0;
+            pos = 0;
+        }
+        else {
+            // place on dendrite
+            seg_id = 1;
+            pos = x.cv/4.0;
+        }
+
+        if (x.cell==1) {
+            x.cv += 5; // offset for cell 1
+        }
+
+        cells[x.cell].add_synapse({seg_id, pos}, parameter_list(x.mech));
+        handles[x.cell].push_back(x);
+    }
+
+    auto n = all_handles.size();
+    std::vector<fvm_cell::target_handle> targets(n);
+    std::vector<fvm_cell::probe_handle> probes;
+
+    fvm_cell fvcell;
+    fvcell.initialize(cells, targets, probes);
+
+    ASSERT_EQ(n, util::size(targets));
+    unsigned i = 0;
+    for (unsigned ci = 0; ci<=1; ++ci) {
+        for (auto h: handles[ci]) {
+            // targets are represented by a pair of mechanism index and instance index
+            const auto& mech = fvcell.mechanisms()[targets[i].mech_id];
+            const auto& cvidx = mech->node_index();
+            EXPECT_EQ(h.mech, mech->name());
+            EXPECT_EQ(h.cv, cvidx[targets[i].index]);
+            EXPECT_EQ(h.cell, targets[i].cell_index);
+            ++i;
+        }
+    }
+}
+
+TEST(fvm_multi, target_handles_onecell)
+{
+    {
+        SCOPED_TRACE("handles: exp2syn only on cell 0");
+        std::vector<handle_info> handles0 = {
+            {0, "exp2syn",  4},
+            {0, "exp2syn",  4},
+            {0, "exp2syn",  3},
+            {0, "exp2syn",  2},
+            {0, "exp2syn",  0},
+            {0, "exp2syn",  1},
+            {0, "exp2syn",  2}
+        };
+        run_target_handle_test(handles0);
+    }
+
+    {
+        SCOPED_TRACE("handles: expsyn only on cell 1");
+        std::vector<handle_info> handles1 = {
+            {1, "expsyn",  4},
+            {1, "expsyn",  4},
+            {1, "expsyn",  3},
+            {1, "expsyn",  2},
+            {1, "expsyn",  0},
+            {1, "expsyn",  1},
+            {1, "expsyn",  2}
+        };
+        run_target_handle_test(handles1);
+    }
+}
+
+TEST(fvm_multi, target_handles_twocell)
+{
+    SCOPED_TRACE("handles: expsyn only on cells 0 and 1");
+    std::vector<handle_info> handles = {
+        {0, "expsyn",  0},
+        {1, "expsyn",  3},
+        {0, "expsyn",  2},
+        {1, "expsyn",  2},
+        {0, "expsyn",  4},
+        {1, "expsyn",  1},
+        {1, "expsyn",  4}
+    };
+    run_target_handle_test(handles);
+}
+
+TEST(fvm_multi, target_handles_mixed_synapse)
+{
+    SCOPED_TRACE("handles: expsyn and exp2syn on cells 0");
+    std::vector<handle_info> handles = {
+        {0, "expsyn",  4},
+        {0, "exp2syn", 4},
+        {0, "expsyn",  3},
+        {0, "exp2syn", 2},
+        {0, "exp2syn", 0},
+        {0, "expsyn",  1},
+        {0, "expsyn",  2}
+    };
+    run_target_handle_test(handles);
+}
+
+TEST(fvm_multi, target_handles_general)
+{
+    SCOPED_TRACE("handles: expsyn and exp2syn on cells 0 and 1");
+    std::vector<handle_info> handles = {
+        {0, "expsyn",  4},
+        {0, "exp2syn", 2},
+        {0, "exp2syn", 0},
+        {1, "exp2syn", 4},
+        {1, "expsyn",  3},
+        {1, "expsyn",  1},
+        {1, "expsyn",  2}
+    };
+    run_target_handle_test(handles);
+}
+

--- a/tests/unit/test_matrix.cpp
+++ b/tests/unit/test_matrix.cpp
@@ -8,6 +8,8 @@
 #include <backends/multicore/fvm.hpp>
 #include <util/span.hpp>
 
+#include "common.hpp"
+
 using namespace nest::mc;
 
 using matrix_type = matrix<nest::mc::multicore::backend>;
@@ -77,3 +79,97 @@ TEST(matrix, solve_host)
         }
     }
 }
+
+TEST(matrix, zero_diagonal)
+{
+    // Combined matrix may have zero-blocks, corresponding to a zero dt.
+    // Zero-blocks are indicated by zero value in the diagonal (the off-diagonal
+    // elements should be ignored).
+    // These submatrices should leave the rhs as-is when solved.
+
+    // Three matrices, sizes 3, 3 and 2, with no branching.
+    std::vector<size_type> p = {0, 0, 1, 3, 3, 5, 5};
+    std::vector<size_type> c = {0, 3, 5, 7};
+    matrix_type m(p, c, vvec(7), vvec(7));
+
+    EXPECT_EQ(7u, m.size());
+    EXPECT_EQ(3u, m.num_cells());
+
+    auto& A = m.state_;
+    A.d =   vvec({2,  3,  2, 0,  0,  4,  5});
+    A.u =   vvec({0, -1, -1, 0, -1,  0, -2});
+    A.rhs = vvec({3,  5,  7, 7,  8, 16, 32});
+
+    // Expected solution:
+    std::vector<value_type> expected = {4, 5, 6, 7, 8, 9, 10};
+
+    m.solve();
+    auto x = m.solution();
+
+    EXPECT_TRUE(testing::seq_almost_eq<double>(expected, x));
+}
+
+TEST(matrix, zero_diagonal_assembled)
+{
+    // Use assemble method to construct same zero-diagonal
+    // test case from CV data.
+
+    using util::assign;
+    using memory::make_view;
+
+    // Combined matrix may have zero-blocks, corresponding to a zero dt.
+    // Zero-blocks are indicated by zero value in the diagonal (the off-diagonal
+    // elements should be ignored).
+    // These submatrices should leave the rhs as-is when solved.
+
+    // Three matrices, sizes 3, 3 and 2, with no branching.
+    std::vector<size_type> p = {0, 0, 1, 3, 3, 5, 5};
+    std::vector<size_type> c = {0, 3, 5, 7};
+
+    // Face conductances.
+    vvec g = {0, 1, 1, 0, 1, 0, 2};
+
+    // dt of 1e-3.
+    vvec t0(3, 0.0);
+    vvec t1(3, 1.0e-3);
+
+    // Capacitances.
+    vvec Cm = {1, 1, 1, 1, 1, 2, 3};
+
+    // Intial voltage of zero; currents alone determine rhs.
+    vvec v(7, 0.0);
+    vvec i = {-3, -5, -7, -6, -9, -16, -32};
+
+    // Expected matrix and rhs:
+    // u = [ 0 -1 -1  0 -1  0 -2]
+    // d = [ 2  3  2  2  2  4  5]
+    // b = [ 3  5  7  2  4 16 32]
+    //
+    // Expected solution:
+    // x = [ 4  5  6  7  8  9 10]
+
+    matrix_type m(p, c, Cm, g);
+    m.assemble(make_view(t0), make_view(t1), make_view(v), make_view(i));
+    m.solve();
+
+    vvec x;
+    assign(x, on_host(m.solution()));
+    std::vector<value_type> expected = {4, 5, 6, 7, 8, 9, 10};
+
+    EXPECT_TRUE(testing::seq_almost_eq<double>(expected, x));
+
+    // Set dt of 2nd (middle) submatrix to zero. Solution
+    // should then return voltage values for that submatrix.
+
+    t0[1] = t1[1];
+    v[3] = 20;
+    v[4] = 30;
+    m.assemble(make_view(t0), make_view(t1), make_view(v), make_view(i));
+    m.solve();
+
+    assign(x, m.solution());
+    expected = {4, 5, 6, 20, 30, 9, 10};
+
+    EXPECT_TRUE(testing::seq_almost_eq<double>(expected, x));
+}
+

--- a/tests/unit/test_matrix.cu
+++ b/tests/unit/test_matrix.cu
@@ -294,8 +294,8 @@ TEST(matrix, assemble)
 
     // Compare the GPU and CPU results.
     // Cast result to float, because we are happy to ignore small differencs
-    std::vector<float> result_h = util::assign_from(m_mc.solution);
-    std::vector<float> result_g = util::assign_from(on_host(m_gpu.solution));
+    std::vector<float> result_h = util::assign_from(m_mc.solution());
+    std::vector<float> result_g = util::assign_from(on_host(m_gpu.solution()));
     EXPECT_TRUE(seq_almost_eq<float>(result_h, result_g));
 }
 
@@ -401,7 +401,83 @@ TEST(matrix, backends)
     // Compare the results.
     // We expect exact equality for the two gpu matrix implementations because both
     // perform the same operations in the same order on the same inputs.
-    std::vector<double> x_flat = assign_from(on_host(flat.solution));
-    std::vector<double> x_intl = assign_from(on_host(intl.solution));
+    std::vector<double> x_flat = assign_from(on_host(flat.solution()));
+    std::vector<double> x_intl = assign_from(on_host(intl.solution()));
     EXPECT_EQ(x_flat, x_intl);
 }
+
+// Test for special zero diagonal behaviour. (see `test_matrix.cpp`.)
+TEST(matrix, zero_diagonal)
+{
+    using util::assign;
+
+    using value_type = gpu::backend::value_type;
+    using size_type = gpu::backend::size_type;
+    using matrix_type = gpu::backend::matrix_state;
+    //using matrix_type = gpu::matrix_state_interleaved<value_type, size_type>;
+    using vvec = std::vector<value_type>;
+
+    // Combined matrix may have zero-blocks, corresponding to a zero dt.
+    // Zero-blocks are indicated by zero value in the diagonal (the off-diagonal
+    // elements should be ignored).
+    // These submatrices should leave the rhs as-is when solved.
+
+    // Three matrices, sizes 3, 3 and 2, with no branching.
+    std::vector<size_type> p = {0, 0, 1, 3, 3, 5, 5};
+    std::vector<size_type> c = {0, 3, 5, 7};
+
+    // Face conductances.
+    std::vector<value_type> g = {0, 1, 1, 0, 1, 0, 2};
+
+    // dt of 1e-3.
+    std::vector<value_type> t0(3, 0.0);
+    std::vector<value_type> t1(3, 1.0e-3);
+
+    // Capacitances.
+    std::vector<value_type> Cm = {1, 1, 1, 1, 1, 2, 3};
+
+    // Intial voltage of zero; currents alone determine rhs.
+    std::vector<value_type> v(7, 0.0);
+    std::vector<value_type> i = {-3, -5, -7, -6, -9, -16, -32};
+
+    // Expected matrix and rhs:
+    // u = [ 0 -1 -1  0 -1  0 -2]
+    // d = [ 2  3  2  2  2  4  5]
+    // b = [ 3  5  7  2  4 16 32]
+    //
+    // Expected solution:
+    // x = [ 4  5  6  7  8  9 10]
+
+    matrix_type m(p, c, Cm, g);
+    auto gpu_t0 = on_gpu(t0);
+    auto gpu_t1 = on_gpu(t1);
+    auto gpu_v  = on_gpu(v);
+    auto gpu_i  = on_gpu(i);
+    m.assemble(gpu_t0, gpu_t1, gpu_v, gpu_i);
+    m.solve();
+
+    vvec x;
+    assign(x, on_host(m.solution()));
+    std::vector<value_type> expected = {4, 5, 6, 7, 8, 9, 10};
+
+    EXPECT_TRUE(testing::seq_almost_eq<double>(expected, x));
+
+    // Set dt of 2nd (middle) submatrix to zero. Solution
+    // should then return voltage values for that submatrix.
+
+    t0[1] = t1[1];
+    gpu_t0 = on_gpu(t0);
+
+    v[3] = 20;
+    v[4] = 30;
+    gpu_v  = on_gpu(v);
+
+    m.assemble(gpu_t0, gpu_t1, gpu_v, gpu_i);
+    m.solve();
+
+    assign(x, on_host(m.solution()));
+    expected = {4, 5, 6, 20, 30, 9, 10};
+
+    EXPECT_TRUE(testing::seq_almost_eq<double>(expected, x));
+}
+

--- a/tests/unit/test_multi_event_stream.cpp
+++ b/tests/unit/test_multi_event_stream.cpp
@@ -1,0 +1,168 @@
+#include <vector>
+#include "../gtest.h"
+
+#include <backends/event.hpp>
+#include <backends/multicore/multi_event_stream.hpp>
+
+using namespace nest::mc;
+
+namespace common_events {
+    // set up four targets across three streams and two mech ids.
+
+    constexpr cell_local_size_type mech_1 = 10u;
+    constexpr cell_local_size_type mech_2 = 13u;
+    constexpr cell_size_type cell_1 = 20u;
+    constexpr cell_size_type cell_2 = 77u;
+    constexpr cell_size_type cell_3 = 33u;
+    constexpr cell_size_type n_cell = 100u;
+
+    target_handle handle[4] = {
+        target_handle(mech_1, 0u, cell_1),
+        target_handle(mech_2, 1u, cell_2),
+        target_handle(mech_1, 4u, cell_2),
+        target_handle(mech_2, 2u, cell_3)
+    };
+
+    // cell_1 (handle 0) has one event at t=3
+    // cell_2 (handle 1 and 2) has two events at t=2 and t=5
+    // cell_3 (handle 3) has one event at t=3
+
+    std::vector<deliverable_event> events = {
+        deliverable_event(2.f, handle[1], 2.f),
+        deliverable_event(3.f, handle[0], 1.f),
+        deliverable_event(3.f, handle[3], 4.f),
+        deliverable_event(5.f, handle[2], 3.f)
+    };
+}
+
+TEST(multi_event_stream, init) {
+    using multi_event_stream = multicore::multi_event_stream;
+    using namespace common_events;
+
+    multi_event_stream m(n_cell);
+    EXPECT_EQ(n_cell, m.n_streams());
+
+    m.init(events);
+    EXPECT_FALSE(m.empty());
+
+    m.clear();
+    EXPECT_TRUE(m.empty());
+}
+
+TEST(multi_event_stream, mark) {
+    using multi_event_stream = multicore::multi_event_stream;
+    using namespace common_events;
+
+    multi_event_stream m(n_cell);
+    ASSERT_EQ(n_cell, m.n_streams());
+
+    m.init(events);
+
+    for (cell_size_type i = 0; i<n_cell; ++i) {
+        EXPECT_TRUE(m.marked_events(i).empty());
+    }
+
+    std::vector<time_type> t_until(n_cell);
+    t_until[cell_1] = 2.f;
+    t_until[cell_2] = 2.5f;
+    t_until[cell_3] = 4.f;
+    m.mark_until_after(t_until);
+
+    // Only two events should be marked: 
+    //     events[0] (with handle 1) at t=2.f on cell_2
+    //     events[2] (with handle 3) at t=3.f on cell_3
+
+    for (cell_size_type i = 0; i<n_cell; ++i) {
+        auto evs = m.marked_events(i);
+        auto n_marked = evs.size();
+        switch (i) {
+        case cell_2:
+            EXPECT_EQ(1u, n_marked);
+            EXPECT_EQ(handle[1].mech_id, evs.front().handle.mech_id);
+            EXPECT_EQ(handle[1].index, evs.front().handle.index);
+            break;
+        case cell_3:
+            EXPECT_EQ(1u, n_marked);
+            EXPECT_EQ(handle[3].mech_id, evs.front().handle.mech_id);
+            EXPECT_EQ(handle[3].index, evs.front().handle.index);
+            break;
+        default:
+            EXPECT_EQ(0u, n_marked);
+            break;
+        }
+    }
+
+    // Drop these events and mark all events up to t=5.f.
+    //     cell_1 should have one marked event (events[1], handle 0)
+    //     cell_2 should have one marked event (events[3], handle 2)
+
+    m.drop_marked_events();
+    t_until.assign(n_cell, 5.f);
+    m.mark_until_after(t_until);
+
+    for (cell_size_type i = 0; i<n_cell; ++i) {
+        auto evs = m.marked_events(i);
+        auto n_marked = evs.size();
+        switch (i) {
+        case cell_1:
+            EXPECT_EQ(1u, n_marked);
+            EXPECT_EQ(handle[0].mech_id, evs.front().handle.mech_id);
+            EXPECT_EQ(handle[0].index, evs.front().handle.index);
+            break;
+        case cell_2:
+            EXPECT_EQ(1u, n_marked);
+            EXPECT_EQ(handle[2].mech_id, evs.front().handle.mech_id);
+            EXPECT_EQ(handle[2].index, evs.front().handle.index);
+            break;
+        default:
+            EXPECT_EQ(0u, n_marked);
+            break;
+        }
+    }
+
+    // No more events after these.
+    EXPECT_FALSE(m.empty());
+    m.drop_marked_events();
+    EXPECT_TRUE(m.empty());
+}
+
+TEST(multi_event_stream, time_if_before) {
+    using multi_event_stream = multicore::multi_event_stream;
+    using namespace common_events;
+
+    multi_event_stream m(n_cell);
+    ASSERT_EQ(n_cell, m.n_streams());
+
+    m.init(events);
+
+    // Test times less than all event times (first event at t=2).
+    std::vector<double> before(n_cell);
+    std::vector<double> after;
+
+    for (unsigned i = 0; i<n_cell; ++i) {
+	before[i] = 0.1+i/(double)n_cell;
+    }
+
+    std::vector<double> t(before);
+    m.event_time_if_before(t);
+
+    EXPECT_EQ(before, t);
+
+    // With times between 2 and 3, expect the event at time t=2
+    // on cell_2 to restrict corresponding element of t.
+
+    for (unsigned i = 0; i<n_cell; ++i) {
+	before[i] = 2.1+0.5*i/(double)n_cell;
+    }
+    t = before;
+    m.event_time_if_before(t);
+
+    for (unsigned i = 0; i<n_cell; ++i) {
+	if (i==cell_2) {
+	    EXPECT_EQ(2., t[i]);
+	}
+	else {
+	    EXPECT_EQ(before[i], t[i]);
+	}
+    }
+}

--- a/tests/unit/test_multi_event_stream.cu
+++ b/tests/unit/test_multi_event_stream.cu
@@ -1,0 +1,242 @@
+#include <cstdio>
+#include <random>
+#include <vector>
+
+#include <cuda.h>
+#include "../gtest.h"
+
+#include <backends/event.hpp>
+#include <backends/gpu/multi_event_stream.hpp>
+#include <backends/gpu/kernels/time_ops.hpp>
+#include <memory/wrappers.hpp>
+#include <util/rangeutil.hpp>
+
+using namespace nest::mc;
+
+namespace common_events {
+    // set up four targets across three streams and two mech ids.
+
+    constexpr cell_local_size_type mech_1 = 10u;
+    constexpr cell_local_size_type mech_2 = 13u;
+    constexpr cell_size_type cell_1 = 20u;
+    constexpr cell_size_type cell_2 = 77u;
+    constexpr cell_size_type cell_3 = 33u;
+    constexpr cell_size_type n_cell = 100u;
+
+    target_handle handle[4] = {
+        target_handle(mech_1, 0u, cell_1),
+        target_handle(mech_2, 1u, cell_2),
+        target_handle(mech_1, 4u, cell_2),
+        target_handle(mech_2, 2u, cell_3)
+    };
+
+    // cell_1 (handle 0) has one event at t=3
+    // cell_2 (handle 1 and 2) has two events at t=2 and t=5
+    // cell_3 (handle 3) has one event at t=3
+
+    std::vector<deliverable_event> events = {
+        deliverable_event(2.f, handle[1], 2.f),
+        deliverable_event(3.f, handle[0], 1.f),
+        deliverable_event(3.f, handle[3], 4.f),
+        deliverable_event(5.f, handle[2], 3.f)
+    };
+}
+
+TEST(multi_event_stream, init) {
+    using multi_event_stream = gpu::multi_event_stream;
+    using namespace common_events;
+
+    multi_event_stream m(n_cell);
+    EXPECT_EQ(n_cell, m.n_streams());
+
+    m.init(events);
+    EXPECT_FALSE(m.empty());
+
+    m.clear();
+    EXPECT_TRUE(m.empty());
+}
+
+struct ev_info {
+    unsigned mech_id;
+    unsigned index;
+    double weight;
+};
+
+__global__
+void copy_marked_events_kernel(
+    unsigned ci,
+    gpu::multi_event_stream::span_state state,
+    ev_info* store,
+    unsigned& count,
+    unsigned max_ev)
+{
+    // use only one thread here
+    if (threadIdx.x || blockIdx.x) return;
+
+    unsigned k = 0;
+    for (auto j = state.span_begin[ci]; j<state.mark[ci]; ++j) {
+        if (k>=max_ev) break;
+        store[k++] = {state.ev_mech_id[j], state.ev_index[j], state.ev_weight[j]};
+    }
+    count = k;
+}
+
+std::vector<ev_info> copy_marked_events(int ci, gpu::multi_event_stream& m) {
+    unsigned max_ev = 1000;
+    memory::device_vector<ev_info> store(max_ev);
+    memory::device_vector<unsigned> counter(1);
+
+    copy_marked_events_kernel<<<1,1>>>(ci, m.delivery_data(), store.data(), *counter.data(), max_ev);
+    unsigned n_ev = counter[0];
+    std::vector<ev_info> ev(n_ev);
+    memory::copy(store(0, n_ev), ev);
+    return ev;
+}
+
+TEST(multi_event_stream, mark) {
+    using multi_event_stream = gpu::multi_event_stream;
+    using namespace common_events;
+
+    multi_event_stream m(n_cell);
+    ASSERT_EQ(n_cell, m.n_streams());
+
+    m.init(events);
+
+    for (cell_size_type i = 0; i<n_cell; ++i) {
+        EXPECT_TRUE(copy_marked_events(i, m).empty());
+    }
+
+    memory::device_vector<double> t_until(n_cell);
+    t_until[cell_1] = 2.;
+    t_until[cell_2] = 2.5;
+    t_until[cell_3] = 4.;
+
+    m.mark_until_after(t_until);
+
+    // Only two events should be marked: 
+    //     events[0] (with handle 1) at t=2 on cell_2
+    //     events[2] (with handle 3) at t=3 on cell_3
+
+    for (cell_size_type i = 0; i<n_cell; ++i) {
+        auto evs = copy_marked_events(i, m);
+        auto n_marked = evs.size();
+        switch (i) {
+        case cell_2:
+            ASSERT_EQ(1u, n_marked);
+            EXPECT_EQ(handle[1].mech_id, evs.front().mech_id);
+            EXPECT_EQ(handle[1].index, evs.front().index);
+            break;
+        case cell_3:
+            ASSERT_EQ(1u, n_marked);
+            EXPECT_EQ(handle[3].mech_id, evs.front().mech_id);
+            EXPECT_EQ(handle[3].index, evs.front().index);
+            break;
+        default:
+            EXPECT_EQ(0u, n_marked);
+            break;
+        }
+    }
+
+    // Drop these events and mark all events up to t=5.
+    //     cell_1 should have one marked event (events[1], handle 0)
+    //     cell_2 should have one marked event (events[3], handle 2)
+
+    m.drop_marked_events();
+    memory::fill(t_until, 5.);
+    m.mark_until_after(memory::make_view(t_until));
+
+    for (cell_size_type i = 0; i<n_cell; ++i) {
+        auto evs = copy_marked_events(i, m);
+        auto n_marked = evs.size();
+        switch (i) {
+        case cell_1:
+            ASSERT_EQ(1u, n_marked);
+            EXPECT_EQ(handle[0].mech_id, evs.front().mech_id);
+            EXPECT_EQ(handle[0].index, evs.front().index);
+            break;
+        case cell_2:
+            ASSERT_EQ(1u, n_marked);
+            EXPECT_EQ(handle[2].mech_id, evs.front().mech_id);
+            EXPECT_EQ(handle[2].index, evs.front().index);
+            break;
+        default:
+            EXPECT_EQ(0u, n_marked);
+            break;
+        }
+    }
+
+    // No more events after these.
+    EXPECT_FALSE(m.empty());
+    m.drop_marked_events();
+    EXPECT_TRUE(m.empty());
+}
+
+TEST(multi_event_stream, time_if_before) {
+    using multi_event_stream = gpu::multi_event_stream;
+    using namespace common_events;
+
+    multi_event_stream m(n_cell);
+    ASSERT_EQ(n_cell, m.n_streams());
+
+    m.init(events);
+
+    // Test times less than all event times (first event at t=2).
+    std::vector<double> before(n_cell);
+    std::vector<double> after;
+
+    for (unsigned i = 0; i<n_cell; ++i) {
+	before[i] = 0.1+i/(double)n_cell;
+    }
+
+    memory::device_vector<double> t = memory::on_gpu(before);
+    m.event_time_if_before(t);
+    util::assign(after, memory::on_host(t));
+
+    EXPECT_EQ(before, after);
+
+    // With times between 2 and 3, expect the event at time t=2
+    // on cell_2 to restrict corresponding element of t.
+
+    for (unsigned i = 0; i<n_cell; ++i) {
+	before[i] = 2.1+0.5*i/(double)n_cell;
+    }
+    t = memory::make_view(before);
+    m.event_time_if_before(t);
+    util::assign(after, memory::on_host(t));
+
+    for (unsigned i = 0; i<n_cell; ++i) {
+	if (i==cell_2) {
+	    EXPECT_EQ(2., after[i]);
+	}
+	else {
+	    EXPECT_EQ(before[i], after[i]);
+	}
+    }
+}
+
+TEST(multi_event_stream, any_time_before) {
+    constexpr std::size_t n = 10000;
+    std::minstd_rand R;
+    std::uniform_real_distribution<float> g(0, 10);
+
+    std::vector<double> t(n);
+    std::generate(t.begin(), t.end(), [&]{ return g(R); });
+
+    memory::device_vector<double> t0 = memory::on_gpu(t);
+
+    double tmin = *std::min_element(t.begin(), t.end());
+    EXPECT_TRUE(gpu::any_time_before(n, t0.data(), tmin+0.01));
+    EXPECT_FALSE(gpu::any_time_before(n, t0.data(), tmin));
+
+    memory::device_vector<double> t1 = memory::on_gpu(t);
+    EXPECT_FALSE(gpu::any_time_before(n, t0.data(), t1.data()));
+
+    t[2*n/3] += 20;
+    t1 = memory::on_gpu(t);
+    EXPECT_TRUE(gpu::any_time_before(n, t0.data(), t1.data()));
+
+    t[2*n/3] -= 30;
+    t1 = memory::on_gpu(t);
+    EXPECT_FALSE(gpu::any_time_before(n, t0.data(), t1.data()));
+}
+


### PR DESCRIPTION
Testing indicates that this implementation gives bit-for-bit identical results on the GPU with different group sizes.

* Virtualize `mechanism::deliver_events`.
* Add unit tests for `multi_event_stream`.
* Perform correct behaviour for cell dt==0 case.
* Add dt==0 unit tests for multicore and gpu back-end matrices.
* Split CUDA implementation for `gpu::multi_event_stream` into own .cu file.
* Use a cached copy of the per-cell time vector for queries in `fvm_multicell`.
* Add trace csv output option to miniapp.
* Add GPU kernel and unit test for end-of-integration time step test. By default, keep using the copy-to-host-and-test method, as it is faster for cell counts up to circa 10k; investigate adaptive/threshold solutions in the future.

Incorporates some PRs that are merged or pending on master:
* Add micro-benchmark for device vector comparison (PR #262).
* Incorporate synapse–target association bugfix and add unit tests (PR #277).
* Fix interleaved matrix data race issues (PR #280).