### PR TITLE
Reduce asynchronous integration overheads

### DIFF
--- a/modcc/cprinter.cpp
+++ b/modcc/cprinter.cpp
@@ -88,8 +88,8 @@ std::string CPrinter::emit_source() {
     //////////////////////////////////////////////
     int num_vars = array_variables.size();
     text_.add_line();
-    text_.add_line(class_name + "(size_type mech_id, const_iview vec_ci, const_view vec_t, const_view vec_t_to, view vec_v, view vec_i, array&& weights, iarray&& node_index)");
-    text_.add_line(":   base(mech_id, vec_ci, vec_t, vec_t_to, vec_v, vec_i, std::move(node_index))");
+    text_.add_line(class_name + "(size_type mech_id, const_iview vec_ci, const_view vec_t, const_view vec_t_to, const_view vec_dt, view vec_v, view vec_i, array&& weights, iarray&& node_index)");
+    text_.add_line(":   base(mech_id, vec_ci, vec_t, vec_t_to, vec_dt, vec_v, vec_i, std::move(node_index))");
     text_.add_line("{");
     text_.increase_indentation();
     text_.add_gutter() << "size_type num_fields = " << num_vars << ";";
@@ -379,6 +379,7 @@ std::string CPrinter::emit_source() {
     text_.add_line("using base::vec_ci_;");
     text_.add_line("using base::vec_t_;");
     text_.add_line("using base::vec_t_to_;");
+    text_.add_line("using base::vec_dt_;");
     text_.add_line("using base::vec_v_;");
     text_.add_line("using base::vec_i_;");
     text_.add_line("using base::node_index_;");

--- a/modcc/cudaprinter.cpp
+++ b/modcc/cudaprinter.cpp
@@ -189,8 +189,8 @@ CUDAPrinter::CUDAPrinter(Module &m, bool o)
 
     int num_vars = array_variables.size();
     text_.add_line();
-    text_.add_line(class_name + "(size_type mech_id, const_iview vec_ci, const_view vec_t, const_view vec_t_to, view vec_v, view vec_i, array&& weights, iarray&& node_index):");
-    text_.add_line("   base(mech_id, vec_ci, vec_t, vec_t_to, vec_v, vec_i, std::move(node_index))");
+    text_.add_line(class_name + "(size_type mech_id, const_iview vec_ci, const_view vec_t, const_view vec_t_to, const_view vec_dt, view vec_v, view vec_i, array&& weights, iarray&& node_index):");
+    text_.add_line("   base(mech_id, vec_ci, vec_t, vec_t_to, vec_dt, vec_v, vec_i, std::move(node_index))");
     text_.add_line("{");
     text_.increase_indentation();
     text_.add_gutter() << "size_type num_fields = " << num_vars << ";";
@@ -486,6 +486,7 @@ CUDAPrinter::CUDAPrinter(Module &m, bool o)
     text_.add_line("using base::vec_ci_;");
     text_.add_line("using base::vec_t_;");
     text_.add_line("using base::vec_t_to_;");
+    text_.add_line("using base::vec_dt_;");
     text_.add_line("using base::vec_v_;");
     text_.add_line("using base::vec_i_;");
     text_.add_line("using base::node_index_;");

--- a/modcc/cudaprinter.cpp
+++ b/modcc/cudaprinter.cpp
@@ -87,9 +87,11 @@ CUDAPrinter::CUDAPrinter(Module &m, bool o)
     text_.add_line("const I* ci;");
     text_.add_line("const T* vec_t;");
     text_.add_line("const T* vec_t_to;");
+    text_.add_line("const T* vec_dt;");
     param_pack.push_back("vec_ci_.data()");
     param_pack.push_back("vec_t_.data()");
     param_pack.push_back("vec_t_to_.data()");
+    param_pack.push_back("vec_dt_.data()");
 
     text_.add_line("// voltage and current state within the cell");
     text_.add_line("T* vec_v;");

--- a/modcc/module.cpp
+++ b/modcc/module.cpp
@@ -297,24 +297,8 @@ bool Module::semantic() {
     auto api_state  = state_api.first;
     auto breakpoint = state_api.second; // implies we are building the `nrn_state()` method.
 
-    if(breakpoint) {
-        // Before running semantic pass, insert dt definition and assignment.
-        // Integration dt is determined by the (cell-indexed) variables `t` and `t_to`.
-        auto loc = breakpoint->body()->location();
-        api_state->body()->statements().push_back(
-            make_expression<LocalDeclaration>(loc, "dt"));
-
-        api_state->body()->statements().push_back(
-            binary_expression(loc, tok::eq,
-                make_expression<IdentifierExpression>(loc, "dt"),
-                binary_expression(loc, tok::minus,
-                    make_expression<IdentifierExpression>(loc, "t_to"),
-                    make_expression<IdentifierExpression>(loc, "t"))));
-    }
-
     api_state->semantic(symbols_);
     scope_ptr nrn_state_scope = api_state->scope();
-
 
     if(breakpoint) {
         // Grab SOLVE statements, put them in `nrn_state` after translation.
@@ -470,6 +454,8 @@ void Module::add_variables_to_symbols() {
     create_indexed_variable("current_", "vec_i", tok::plus,
                             accessKind::write, ionKind::none, Location());
     create_indexed_variable("v", "vec_v", tok::eq,
+                            accessKind::read,  ionKind::none, Location());
+    create_indexed_variable("dt", "vec_dt", tok::eq,
                             accessKind::read,  ionKind::none, Location());
 
     // add cell-indexed variables to the table

--- a/modcc/sss
+++ b/modcc/sss
@@ -1,0 +1,21 @@
+__inline __m512d
+__attribute__ ((__gnu_inline__, __always_inline__, __artificial__))
+_mm512_i32gather_pd (__m256i __index, double const *__addr, int __scale)
+{
+  __m512d v1_old = _mm512_undefined_pd ();
+  __mmask8 mask = 0xFF;
+
+  return (__m512d) __builtin_ia32_gathersiv8df ((__v8df) v1_old,
+                                                __addr,
+                                                (__v8si) __index, mask,
+                                                __scale);
+}
+
+_mm256_i32gather_pd (double const *base, __m128i index, const int scale)
+
+
+clean up:
+
+_mm512_i32gather_pd(__m256i index, double const *base, int scale)
+_mm256_i32gather_pd(double const *base, __m128i index, int scale)
+

--- a/src/backends/fvm.hpp
+++ b/src/backends/fvm.hpp
@@ -16,7 +16,7 @@ struct null_backend: public multicore::backend {
         const std::string&,
         size_type,
         const_iview,
-        const_view, const_view,
+        const_view, const_view, const_view,
         view, view,
         const std::vector<value_type>&,
         const std::vector<size_type>&)

--- a/src/backends/gpu/fvm.hpp
+++ b/src/backends/gpu/fvm.hpp
@@ -116,11 +116,11 @@ struct backend {
     }
 
     // set the per-cell and per-compartment dt_ from time_to_ - time_.
-    static void set_dt(array& dt_cell, array& dt_comp, const_view time_to, const_view time, const_iview cv_to_cell, array& dt_scratch) {
+    static void set_dt(array& dt_cell, array& dt_comp, const_view time_to, const_view time, const_iview cv_to_cell) {
         size_type ncell = util::size(dt_cell);
         size_type ncomp = util::size(dt_comp);
 
-        nest::mc::gpu::set_dt<value_type, size_type>(ncell, ncomp, dt_cell.data(), dt_comp.data(), time_to.size(), time_to.data(), cv_to_cell.data());
+        nest::mc::gpu::set_dt<value_type, size_type>(ncell, ncomp, dt_cell.data(), dt_comp.data(), time_to.data(), time.data(), cv_to_cell.data());
     }
 
 private:

--- a/src/backends/gpu/kernels/assemble_matrix.hpp
+++ b/src/backends/gpu/kernels/assemble_matrix.hpp
@@ -22,15 +22,14 @@ void assemble_matrix_flat(
         const T* current,
         const T* cv_capacitance,
         const I* cv_to_cell,
-        const T* t,
-        const T* t_to,
+        const T* dt_cell,
         unsigned n)
 {
     const unsigned tid = threadIdx.x + blockDim.x*blockIdx.x;
 
     if (tid<n) {
         auto cid = cv_to_cell[tid];
-        auto dt = t_to[cid] - t[cid];
+        auto dt = dt_cell[cid];
 
         // Note: dt==0 case is expected only at the end of a mindelay/2
         // integration period, and consequently divergence is unlikely
@@ -71,8 +70,7 @@ void assemble_matrix_interleaved(
         const I* sizes,
         const I* starts,
         const I* matrix_to_cell,
-        const T* time,
-        const T* time_to,
+        const T* dt_cell,
         unsigned padded_size, unsigned num_mtx)
 {
     static_assert(BlockWidth*LoadWidth==Threads,
@@ -106,7 +104,7 @@ void assemble_matrix_interleaved(
 
     if (permuted_cid<num_mtx) {
         auto cid = matrix_to_cell[permuted_cid];
-        dt = time_to[cid]-time[cid];
+        dt = dt_cell[cid];
 
         // The 1e-3 is a constant of proportionality required to ensure that the
         // conductance (gi) values have units μS (micro-Siemens).

--- a/src/backends/gpu/kernels/time_ops.hpp
+++ b/src/backends/gpu/kernels/time_ops.hpp
@@ -47,7 +47,7 @@ namespace kernels {
     };
 
     // vector minus: x = y - z
-    template <typename T, typename I, typename Pred>
+    template <typename T, typename I>
     __global__ void vec_minus(I n, T* x, const T* y, const T* z) {
         int i = threadIdx.x+blockIdx.x*blockDim.x;
         if (i<n) {
@@ -56,7 +56,7 @@ namespace kernels {
     }
 
     // vector gather: x[i] = y[index[i]]
-    template <typename T, typename I, typename Pred>
+    template <typename T, typename I>
     __global__ void gather(I n, T* x, const T* y, const I* index) {
         int i = threadIdx.x+blockIdx.x*blockDim.x;
         if (i<n) {
@@ -95,14 +95,16 @@ bool any_time_before(I n, T* t0, U t1) {
 }
 
 template <typename T, typename I>
-void set_dt(I ncell, I ncomp, T* dt_cell, T& dt_comp, const T* time_to, const T* time, const I* cv_to_cell) {
+void set_dt(I ncell, I ncomp, T* dt_cell, T* dt_comp, const T* time_to, const T* time, const I* cv_to_cell) {
     if (!ncell || !ncomp) {
         return;
     }
 
     constexpr int blockwidth = 128;
-    int nblock = 1+(n-1)/blockwidth;
+    int nblock = 1+(ncell-1)/blockwidth;
     kernels::vec_minus<<<nblock, blockwidth>>>(ncell, dt_cell, time_to, time);
+
+    nblock = 1+(ncomp-1)/blockwidth;
     kernels::gather<<<nblock, blockwidth>>>(ncomp, dt_comp, dt_cell, cv_to_cell);
 }
 

--- a/src/backends/gpu/kernels/time_ops.hpp
+++ b/src/backends/gpu/kernels/time_ops.hpp
@@ -45,6 +45,24 @@ namespace kernels {
         __device__ __host__
         bool operator()(const T& a, const T& b) const { return a<b; }
     };
+
+    // vector minus: x = y - z
+    template <typename T, typename I, typename Pred>
+    __global__ void vec_minus(I n, T* x, const T* y, const T* z) {
+        int i = threadIdx.x+blockIdx.x*blockDim.x;
+        if (i<n) {
+            x[i] = y[i]-z[i];
+        }
+    }
+
+    // vector gather: x[i] = y[index[i]]
+    template <typename T, typename I, typename Pred>
+    __global__ void gather(I n, T* x, const T* y, const I* index) {
+        int i = threadIdx.x+blockIdx.x*blockDim.x;
+        if (i<n) {
+            x[i] = y[index[i]];
+        }
+    }
 }
 
 template <typename T, typename I>
@@ -74,6 +92,18 @@ bool any_time_before(I n, T* t0, U t1) {
     r[0] = 0;
     kernels::array_reduce_any<<<nblock, blockwidth>>>(n, t0, t1, kernels::less<T>(), r.data());
     return r[0];
+}
+
+template <typename T, typename I>
+void set_dt(I ncell, I ncomp, T* dt_cell, T& dt_comp, const T* time_to, const T* time, const I* cv_to_cell) {
+    if (!ncell || !ncomp) {
+        return;
+    }
+
+    constexpr int blockwidth = 128;
+    int nblock = 1+(n-1)/blockwidth;
+    kernels::vec_minus<<<nblock, blockwidth>>>(ncell, dt_cell, time_to, time);
+    kernels::gather<<<nblock, blockwidth>>>(ncomp, dt_comp, dt_cell, cv_to_cell);
 }
 
 } // namespace gpu

--- a/src/backends/gpu/matrix_state_flat.hpp
+++ b/src/backends/gpu/matrix_state_flat.hpp
@@ -102,7 +102,7 @@ struct matrix_state_flat {
 
         assemble_matrix_flat<value_type, size_type><<<grid_dim, block_dim>>> (
             d.data(), rhs.data(), invariant_d.data(), voltage.data(),
-            current.data(), cv_capacitance.data(), cv_to_cell.data(), dt.data(), size());
+            current.data(), cv_capacitance.data(), cv_to_cell.data(), dt_cell.data(), size());
     }
 
     void solve() {

--- a/src/backends/gpu/matrix_state_flat.hpp
+++ b/src/backends/gpu/matrix_state_flat.hpp
@@ -90,13 +90,11 @@ struct matrix_state_flat {
     }
 
     // Assemble the matrix
-    // Afterwards the diagonal and RHS will have been set given dt, voltage and current,
-    // where dt is determined by the start and end integration times t and t_to.
-    //   t       [ms]
-    //   t_to    [ms]
+    // Afterwards the diagonal and RHS will have been set given dt, voltage and current.
+    //   dt_cell [ms] (per cell)
     //   voltage [mV]
     //   current [nA]
-    void assemble(const_view t, const_view t_to, const_view voltage, const_view current) {
+    void assemble(const_view dt_cell, const_view voltage, const_view current) {
         // determine the grid dimensions for the kernel
         auto const n = voltage.size();
         auto const block_dim = 128;
@@ -104,7 +102,7 @@ struct matrix_state_flat {
 
         assemble_matrix_flat<value_type, size_type><<<grid_dim, block_dim>>> (
             d.data(), rhs.data(), invariant_d.data(), voltage.data(),
-            current.data(), cv_capacitance.data(), cv_to_cell.data(), t.data(), t_to.data(), size());
+            current.data(), cv_capacitance.data(), cv_to_cell.data(), dt.data(), size());
     }
 
     void solve() {

--- a/src/backends/gpu/matrix_state_interleaved.hpp
+++ b/src/backends/gpu/matrix_state_interleaved.hpp
@@ -226,7 +226,7 @@ struct matrix_state_interleaved {
              voltage.data(), current.data(), cv_capacitance.data(),
              matrix_sizes.data(), matrix_index.data(),
              matrix_to_cell_index.data(),
-             dt.data(), padded_matrix_size(), num_matrices());
+             dt_cell.data(), padded_matrix_size(), num_matrices());
 
     }
 

--- a/src/backends/gpu/matrix_state_interleaved.hpp
+++ b/src/backends/gpu/matrix_state_interleaved.hpp
@@ -208,13 +208,11 @@ struct matrix_state_interleaved {
     }
 
     // Assemble the matrix
-    // Afterwards the diagonal and RHS will have been set given dt, voltage and current,
-    // where dt is determined by the start and end integration times t and t_to.
-    //   t       [ms]
-    //   t_to    [ms]
+    // Afterwards the diagonal and RHS will have been set given dt, voltage and current.
+    //   dt_cell [ms] (per cell)
     //   voltage [mV]
     //   current [nA]
-    void assemble(const_view t, const_view t_to, const_view voltage, const_view current) {
+    void assemble(const_view dt_cell, const_view voltage, const_view current) {
         constexpr auto bd = impl::block_dim();
         constexpr auto lw = impl::load_width();
         constexpr auto block_dim = bd*lw;
@@ -228,7 +226,7 @@ struct matrix_state_interleaved {
              voltage.data(), current.data(), cv_capacitance.data(),
              matrix_sizes.data(), matrix_index.data(),
              matrix_to_cell_index.data(),
-             t.data(), t_to.data(), padded_matrix_size(), num_matrices());
+             dt.data(), padded_matrix_size(), num_matrices());
 
     }
 

--- a/src/backends/gpu/stimulus.hpp
+++ b/src/backends/gpu/stimulus.hpp
@@ -54,8 +54,8 @@ public:
 
     static constexpr size_type no_mech_id = (size_type)-1;
 
-    stimulus(const_iview vec_ci, const_view vec_t, const_view vec_t_to, view vec_v, view vec_i, iarray&& node_index):
-        base(no_mech_id, vec_ci, vec_t, vec_t_to, vec_v, vec_i, std::move(node_index))
+    stimulus(const_iview vec_ci, const_view vec_t, const_view vec_t_to, const_view vec_dt, view vec_v, view vec_i, iarray&& node_index):
+        base(no_mech_id, vec_ci, vec_t, vec_t_to, vec_dt, vec_v, vec_i, std::move(node_index))
     {}
 
     using base::size;

--- a/src/backends/multicore/matrix_state.hpp
+++ b/src/backends/multicore/matrix_state.hpp
@@ -65,18 +65,17 @@ public:
 
 
     // Assemble the matrix
-    // Afterwards the diagonal and RHS will have been set given dt, voltage and current
-    //   time    [ms]
-    //   time_to [ms]
+    // Afterwards the diagonal and RHS will have been set given dt, voltage and current.
+    //   dt_cell [ms] (per cell)
     //   voltage [mV]
     //   current [nA]
-    void assemble(const_view time, const_view time_to, const_view voltage, const_view current) {
+    void assemble(const_view dt_cell, const_view voltage, const_view current) {
         auto cell_cv_part = util::partition_view(cell_cv_divs);
         const size_type ncells = cell_cv_part.size();
 
         // loop over submatrices
         for (auto m: util::make_span(0, ncells)) {
-            auto dt = time_to[m]-time[m];
+            auto dt = dt_cell[m];
 
             if (dt>0) {
                 value_type factor = 1e-3/dt;

--- a/src/backends/multicore/stimulus.hpp
+++ b/src/backends/multicore/stimulus.hpp
@@ -30,8 +30,8 @@ public:
 
     static constexpr size_type no_mech_id = (size_type)-1;
 
-    stimulus(const_iview vec_ci, const_view vec_t, const_view vec_t_to, view vec_v, view vec_i, iarray&& node_index):
-        base(no_mech_id, vec_ci, vec_t, vec_t_to, vec_v, vec_i, std::move(node_index))
+    stimulus(const_iview vec_ci, const_view vec_t, const_view vec_t_to, const_view vec_dt, view vec_v, view vec_i, iarray&& node_index):
+        base(no_mech_id, vec_ci, vec_t, vec_t_to, vec_dt, vec_v, vec_i, std::move(node_index))
     {}
 
     using base::size;

--- a/src/matrix.hpp
+++ b/src/matrix.hpp
@@ -69,8 +69,8 @@ public:
     }
 
     /// Assemble the matrix for given dt
-    void assemble(const_view t, const_view t_to, const_view voltage, const_view current) {
-        state_.assemble(t, t_to, voltage, current);
+    void assemble(const_view dt_cell, const_view voltage, const_view current) {
+        state_.assemble(dt_cell, voltage, current);
     }
 
     /// Get a view of the solution

--- a/src/mc_cell_group.hpp
+++ b/src/mc_cell_group.hpp
@@ -117,36 +117,41 @@ public:
 
         lowered_.setup_integration(tfinal, dt);
 
+        util::optional<time_type> first_sample_time = sample_events_.time_if_before(tfinal);
         std::vector<sample_event> requeue_sample_events;
         while (!lowered_.integration_complete()) {
             // Take any pending samples.
             // TODO: Placeholder: this will be replaced by a backend polling implementation.
 
-            PE("sampling");
-            time_type cell_max_time = lowered_.max_time();
 
-            requeue_sample_events.clear();
-            while (auto m = sample_events_.pop_if_before(cell_max_time)) {
-                auto& s = samplers_[m->sampler_index];
-                EXPECTS((bool)s.sampler);
+            if (first_sample_time) {
+                PE("sampling");
+                time_type cell_max_time = lowered_.max_time();
 
-                time_type cell_time = lowered_.time(s.cell_gid-gid_base_);
-                if (cell_time<m->time) {
-                    // This cell hasn't reached this sample time yet.
-                    requeue_sample_events.push_back(*m);
-                }
-                else {
-                    auto next = s.sampler(cell_time, lowered_.probe(s.handle));
-                    if (next) {
-                        m->time = std::max(*next, cell_time);
+                requeue_sample_events.clear();
+                while (auto m = sample_events_.pop_if_before(cell_max_time)) {
+                    auto& s = samplers_[m->sampler_index];
+                    EXPECTS((bool)s.sampler);
+
+                    time_type cell_time = lowered_.time(s.cell_gid-gid_base_);
+                    if (cell_time<m->time) {
+                        // This cell hasn't reached this sample time yet.
                         requeue_sample_events.push_back(*m);
                     }
+                    else {
+                        auto next = s.sampler(cell_time, lowered_.probe(s.handle));
+                        if (next) {
+                            m->time = std::max(*next, cell_time);
+                            requeue_sample_events.push_back(*m);
+                        }
+                    }
                 }
+                for (auto& ev: requeue_sample_events) {
+                    sample_events_.push(std::move(ev));
+                }
+                first_sample_time = sample_events_.time_if_before(tfinal);
+                PL();
             }
-            for (auto& ev: requeue_sample_events) {
-                sample_events_.push(std::move(ev));
-            }
-            PL();
 
             // Ask lowered_ cell to integrate 'one step', delivering any
             // events accordingly.

--- a/src/mechanism.hpp
+++ b/src/mechanism.hpp
@@ -41,11 +41,12 @@ public:
 
     using multi_event_stream = typename backend::multi_event_stream;
 
-    mechanism(size_type mech_id, const_iview vec_ci, const_view vec_t, const_view vec_t_to, view vec_v, view vec_i, iarray&& node_index):
+    mechanism(size_type mech_id, const_iview vec_ci, const_view vec_t, const_view vec_t_to, const_view vec_dt, view vec_v, view vec_i, iarray&& node_index):
         mech_id_(mech_id),
         vec_ci_(vec_ci),
         vec_t_(vec_t),
         vec_t_to_(vec_t_to),
+        vec_dt_(vec_dt),
         vec_v_(vec_v),
         vec_i_(vec_i),
         node_index_(std::move(node_index))
@@ -85,6 +86,8 @@ public:
     const_view vec_t_;
     // Maps cell index to integration stop time.
     const_view vec_t_to_;
+    // Maps compartment index to (stop time) - (start time).
+    const_view vec_dt_;
     // Maps compartment index to voltage.
     view vec_v_;
     // Maps compartment index to current.
@@ -102,12 +105,13 @@ auto make_mechanism(
     typename M::const_iview vec_ci,
     typename M::const_view vec_t,
     typename M::const_view vec_t_to,
+    typename M::const_view vec_dt,
     typename M::view vec_v,
     typename M::view vec_i,
     typename M::array&& weights,
     typename M::iarray&& node_indices
 )
-DEDUCED_RETURN_TYPE(util::make_unique<M>(mech_id, vec_ci, vec_t, vec_t_to, vec_v, vec_i, std::move(weights), std::move(node_indices)))
+DEDUCED_RETURN_TYPE(util::make_unique<M>(mech_id, vec_ci, vec_t, vec_t_to, vec_dt, vec_v, vec_i, std::move(weights), std::move(node_indices)))
 
 } // namespace mechanisms
 } // namespace mc

--- a/tests/unit/test_backend.cpp
+++ b/tests/unit/test_backend.cpp
@@ -17,7 +17,7 @@ TEST(backends, gpu_is_null) {
 
         EXPECT_FALSE(backend::has_mechanism("hh"));
         EXPECT_THROW(
-            backend::make_mechanism("hh", 0, backend::const_iview(), backend::const_view(), backend::const_view(), backend::view(), backend::view(), {}, {}),
+            backend::make_mechanism("hh", 0, backend::const_iview(), backend::const_view(), backend::const_view(), backend::const_view(), backend::view(), backend::view(), {}, {}),
             std::runtime_error);
     }
 }

--- a/tests/unit/test_matrix.cpp
+++ b/tests/unit/test_matrix.cpp
@@ -130,8 +130,7 @@ TEST(matrix, zero_diagonal_assembled)
     vvec g = {0, 1, 1, 0, 1, 0, 2};
 
     // dt of 1e-3.
-    vvec t0(3, 0.0);
-    vvec t1(3, 1.0e-3);
+    vvec dt(3, 1.0e-3);
 
     // Capacitances.
     vvec Cm = {1, 1, 1, 1, 1, 2, 3};
@@ -149,7 +148,7 @@ TEST(matrix, zero_diagonal_assembled)
     // x = [ 4  5  6  7  8  9 10]
 
     matrix_type m(p, c, Cm, g);
-    m.assemble(make_view(t0), make_view(t1), make_view(v), make_view(i));
+    m.assemble(make_view(dt), make_view(v), make_view(i));
     m.solve();
 
     vvec x;
@@ -161,10 +160,10 @@ TEST(matrix, zero_diagonal_assembled)
     // Set dt of 2nd (middle) submatrix to zero. Solution
     // should then return voltage values for that submatrix.
 
-    t0[1] = t1[1];
+    dt[1] = 0;
     v[3] = 20;
     v[4] = 30;
-    m.assemble(make_view(t0), make_view(t1), make_view(v), make_view(i));
+    m.assemble(make_view(dt), make_view(v), make_view(i));
     m.solve();
 
     assign(x, m.solution());

--- a/tests/unit/test_matrix.cu
+++ b/tests/unit/test_matrix.cu
@@ -461,7 +461,7 @@ TEST(matrix, zero_diagonal)
     // should then return voltage values for that submatrix.
 
     dt[1] = 0;
-    gpu_t0 = on_gpu(t0);
+    gpu_dt = on_gpu(dt);
 
     v[3] = 20;
     v[4] = 30;

--- a/tests/unit/test_matrix.cu
+++ b/tests/unit/test_matrix.cu
@@ -281,16 +281,15 @@ TEST(matrix, assemble)
     auto m_gpu = gpu_state(p, cell_index, Cm, g); // on gpu
 
     // Set the integration times for the cells to be between 0.1 and 0.2 ms.
-    std::vector<T> time(num_mtx, 0);
-    std::vector<T> time_to(num_mtx);
+    std::vector<T> dt(num_mtx);
 
     auto dt_dist = std::uniform_real_distribution<T>(0.1, 0.2);
-    std::generate(time_to.begin(), time_to.end(), [&](){return dt_dist(gen);});
+    std::generate(dt.begin(), dt.end(), [&](){return dt_dist(gen);});
 
     // Voltage and current values
-    m_mc.assemble(host_array(time), host_array(time_to), host_array(group_size, -64), host_array(group_size, 10));
+    m_mc.assemble(host_array(dt), host_array(group_size, -64), host_array(group_size, 10));
     m_mc.solve();
-    m_gpu.assemble(on_gpu(time), on_gpu(time_to), gpu_array(group_size, -64), gpu_array(group_size, 10));
+    m_gpu.assemble(on_gpu(dt), gpu_array(group_size, -64), gpu_array(group_size, 10));
     m_gpu.solve();
 
     // Compare the GPU and CPU results.
@@ -381,20 +380,18 @@ TEST(matrix, backends)
     auto intl = state_intl(p, cell_cv_divs, Cm, g); // interleaved
 
     // Set the integration times for the cells to be between 0.01 and 0.02 ms.
-    std::vector<T> time(num_mtx, 0);
-    std::vector<T> time_to(num_mtx);
+    std::vector<T> dt(num_mtx, 0);
 
     auto dt_dist = std::uniform_real_distribution<T>(0.01, 0.02);
-    std::generate(time_to.begin(), time_to.end(), [&](){return dt_dist(gen);});
+    std::generate(dt.begin(), dt.end(), [&](){return dt_dist(gen);});
 
     // Voltage and current values.
-    auto gpu_t = on_gpu(time);
-    auto gpu_t_to = on_gpu(time_to);
+    auto gpu_dt = on_gpu(dt);
     auto gpu_v = on_gpu(v);
     auto gpu_i = on_gpu(i);
 
-    flat.assemble(gpu_t, gpu_t_to, gpu_v, gpu_i);
-    intl.assemble(gpu_t, gpu_t_to, gpu_v, gpu_i);
+    flat.assemble(gpu_dt, gpu_v, gpu_i);
+    intl.assemble(gpu_dt, gpu_v, gpu_i);
 
     flat.solve();
     intl.solve();
@@ -415,7 +412,6 @@ TEST(matrix, zero_diagonal)
     using value_type = gpu::backend::value_type;
     using size_type = gpu::backend::size_type;
     using matrix_type = gpu::backend::matrix_state;
-    //using matrix_type = gpu::matrix_state_interleaved<value_type, size_type>;
     using vvec = std::vector<value_type>;
 
     // Combined matrix may have zero-blocks, corresponding to a zero dt.
@@ -431,8 +427,7 @@ TEST(matrix, zero_diagonal)
     std::vector<value_type> g = {0, 1, 1, 0, 1, 0, 2};
 
     // dt of 1e-3.
-    std::vector<value_type> t0(3, 0.0);
-    std::vector<value_type> t1(3, 1.0e-3);
+    std::vector<value_type> dt(3, 1.0e-3);
 
     // Capacitances.
     std::vector<value_type> Cm = {1, 1, 1, 1, 1, 2, 3};
@@ -450,11 +445,10 @@ TEST(matrix, zero_diagonal)
     // x = [ 4  5  6  7  8  9 10]
 
     matrix_type m(p, c, Cm, g);
-    auto gpu_t0 = on_gpu(t0);
-    auto gpu_t1 = on_gpu(t1);
+    auto gpu_dt = on_gpu(dt);
     auto gpu_v  = on_gpu(v);
     auto gpu_i  = on_gpu(i);
-    m.assemble(gpu_t0, gpu_t1, gpu_v, gpu_i);
+    m.assemble(gpu_dt, gpu_v, gpu_i);
     m.solve();
 
     vvec x;
@@ -466,14 +460,14 @@ TEST(matrix, zero_diagonal)
     // Set dt of 2nd (middle) submatrix to zero. Solution
     // should then return voltage values for that submatrix.
 
-    t0[1] = t1[1];
+    dt[1] = 0;
     gpu_t0 = on_gpu(t0);
 
     v[3] = 20;
     v[4] = 30;
     gpu_v  = on_gpu(v);
 
-    m.assemble(gpu_t0, gpu_t1, gpu_v, gpu_i);
+    m.assemble(gpu_dt, gpu_v, gpu_i);
     m.solve();
 
     assign(x, on_host(m.solution()));

--- a/tests/unit/test_mechanisms.cpp
+++ b/tests/unit/test_mechanisms.cpp
@@ -46,9 +46,10 @@ TEST(mechanisms, helpers) {
     multicore::backend::array vec_v(n, 0.);
     multicore::backend::array vec_t(ncell, 0.);
     multicore::backend::array vec_t_to(ncell, 0.);
+    multicore::backend::array vec_dt(n, 0.);
 
     auto mech = multicore::backend::make_mechanism("hh", 0,
-            memory::make_view(cell_index), vec_t, vec_t_to,
+            memory::make_view(cell_index), vec_t, vec_t_to, vec_dt,
             vec_v, vec_i, weights, node_index);
 
     EXPECT_EQ(mech->name(), "hh");
@@ -57,7 +58,7 @@ TEST(mechanisms, helpers) {
     // check that an out_of_range exception is thrown if an invalid mechanism is requested
     ASSERT_THROW(
         multicore::backend::make_mechanism("dachshund", 0,
-            memory::make_view(cell_index), vec_t, vec_t_to,
+            memory::make_view(cell_index), vec_t, vec_t_to, vec_dt,
             vec_v, vec_i, weights, node_index),
         std::out_of_range
     );
@@ -146,6 +147,7 @@ TYPED_TEST_P(mechanisms, update) {
     typename mechanism_type::iarray cell_index(num_comp, 0);
     typename mechanism_type::array  time(num_cell, 2.);
     typename mechanism_type::array  time_to(num_cell, 2.1);
+    typename mechanism_type::array  dt(num_comp, 2.1-2.);
 
     array_init(voltage, nest::mc::util::cyclic_view({ -65.0, -61.0, -63.0 }));
     array_init(current, nest::mc::util::cyclic_view({   1.0,   0.9,   1.1 }));
@@ -178,12 +180,12 @@ TYPED_TEST_P(mechanisms, update) {
 
     // Create mechanisms
     auto mech = nest::mc::mechanisms::make_mechanism<mechanism_type>(
-        0, cell_index, time, time_to,
+        0, cell_index, time, time_to, dt,
         voltage, current, std::move(weights), std::move(node_index)
     );
 
     auto mech_proto = nest::mc::mechanisms::make_mechanism<proto_mechanism_type>(
-        0, cell_index, time, time_to,
+        0, cell_index, time, time_to, dt,
         voltage_copy, current_copy,
         std::move(weights_copy), std::move(node_index_copy)
     );

--- a/tests/unit/test_synapses.cpp
+++ b/tests/unit/test_synapses.cpp
@@ -55,13 +55,14 @@ TEST(synapses, expsyn_basic_state)
     synapse_type::iarray cell_index(num_comp, 0);
     synapse_type::array time(num_cell, 0);
     synapse_type::array time_to(num_cell, 0.1);
+    synapse_type::array dt(num_comp, 0.1);
 
     std::vector<size_type> node_index(num_syn, 0);
     std::vector<value_type> weights(num_syn, 1.0);
     synapse_type::array voltage(num_comp, -65.0);
     synapse_type::array current(num_comp,   1.0);
 
-    auto mech = mechanisms::make_mechanism<synapse_type>(0, cell_index, time, time_to, voltage, current, weights, node_index);
+    auto mech = mechanisms::make_mechanism<synapse_type>(0, cell_index, time, time_to, dt, voltage, current, weights, node_index);
     auto ptr = dynamic_cast<synapse_type*>(mech.get());
 
     auto n = ptr->size();
@@ -115,13 +116,14 @@ TEST(synapses, exp2syn_basic_state)
     synapse_type::iarray cell_index(num_comp, 0);
     synapse_type::array time(num_cell, 0);
     synapse_type::array time_to(num_cell, 0.1);
+    synapse_type::array dt(num_comp, 0.1);
 
     std::vector<size_type> node_index(num_syn, 0);
     std::vector<value_type> weights(num_syn, 1.0);
     synapse_type::array voltage(num_comp, -65.0);
     synapse_type::array current(num_comp,   1.0);
 
-    auto mech = mechanisms::make_mechanism<synapse_type>(0, cell_index, time, time_to, voltage, current, weights, node_index);
+    auto mech = mechanisms::make_mechanism<synapse_type>(0, cell_index, time, time_to, dt, voltage, current, weights, node_index);
     auto ptr = dynamic_cast<synapse_type*>(mech.get());
 
     auto n = ptr->size();


### PR DESCRIPTION
*NOTE:* This PR includes the contents of PR #284 — that PR should be merged first.

Fixes #285.

Addresses issue identified in #285, reducing asynchronous integration implementation overhead to approximately 11-12% in the miniapp example tested.

* Explicitly compute and store per-cell and per-compartment `dt` from integration time bounds.
* Determine lower bound on number of integration steps per interval in order to avoid explicit checking of minimum cell times each step.
* Avoid any time value checking for samplers in the integration loop if none of them could be triggered in the interval.
