### PR TITLE
Fix bug with comparison operator for spikes

### DIFF
--- a/src/spike.hpp
+++ b/src/spike.hpp
@@ -20,6 +20,12 @@ struct basic_spike {
     basic_spike(id_type s, time_type t):
         source(s), time(t)
     {}
+
+    /// Less than comparison operator for nest::mc::spike<> values:
+    /// spikes are ordered by spike time, for use in sorting and queueing.
+    friend bool operator<(basic_spike lhs, basic_spike rhs) {
+        return lhs.time < rhs.time;
+    }
 };
 
 /// Standard specialization:
@@ -33,12 +39,3 @@ template <typename I>
 std::ostream& operator<<(std::ostream& o, nest::mc::basic_spike<I> s) {
     return o << "spike[t " << s.time << ", src " << s.source << "]";
 }
-
-/// Less than comparison operator for nest::mc::spike<> values:
-/// spikes are ordered by spike time, for use in sorting and queueing.
-template <typename I>
-bool operator<(nest::mc::basic_spike<I> lhs, nest::mc::basic_spike<I> rhs) {
-    return lhs.time < rhs.time;
-}
-
-

--- a/tests/unit/test_spikes.cpp
+++ b/tests/unit/test_spikes.cpp
@@ -17,6 +17,39 @@ using backend = multicore::backend;
 using backend = USE_BACKEND;
 #endif
 
+TEST(spikes, ordering) {
+    {
+        spike s1({0,0}, 1), s2({0,0}, 2);
+        EXPECT_TRUE(s1<s2);
+    }
+    {
+        spike s1({0,0}, 1), s2({0,0}, 1);
+        EXPECT_FALSE(s1<s2);
+    }
+    {
+        spike s1({0,0}, 2), s2({0,0}, 1);
+        EXPECT_FALSE(s1<s2);
+    }
+}
+
+TEST(spikes, sorting) {
+    std::vector<spike> spikes = {
+        {{0,0}, 1},
+        {{0,0}, 2},
+        {{0,0}, 0},
+        {{0,0}, 3},
+        {{0,0}, 1},
+        {{0,0}, 2},
+    };
+
+    std::sort(spikes.begin(), spikes.end());
+
+    auto it = spikes.begin();
+    while (++it!=spikes.end()) {
+        EXPECT_TRUE(it->time >= (it-1)->time);
+    }
+}
+
 TEST(spikes, threshold_watcher) {
     using backend = multicore::backend;
     using size_type = backend::size_type;


### PR DESCRIPTION
The less than operator for spikes was not in the nest::mc namespace,
so it was not being picked up by STL algoriths and containers.
This patch makes it a friend operator of the `nest::mc::basic_spike`,
and adds some unit tests to varify that STL algorithms can use
containers of spikes.

fixes #315.