### PR TITLE
Move common primitive types across fvm implementations to common header.

### DIFF
--- a/src/backends/fvm_types.hpp
+++ b/src/backends/fvm_types.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <common_types.hpp>
+
+// Basic types shared across FVM implementations/backends.
+
+namespace nest {
+namespace mc {
+
+using fvm_value_type = double;
+using fvm_size_type = cell_local_size_type;
+
+} // namespace mc
+} // namespace nest

--- a/src/backends/gpu/fvm.hpp
+++ b/src/backends/gpu/fvm.hpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include <backends/event.hpp>
+#include <backends/fvm_types.hpp>
 #include <common_types.hpp>
 #include <mechanism.hpp>
 #include <memory/memory.hpp>
@@ -26,8 +27,8 @@ struct backend {
     }
 
     /// define the real and index types
-    using value_type = double;
-    using size_type  = nest::mc::cell_lid_type;
+    using value_type = fvm_value_type;
+    using size_type  = fvm_size_type;
 
     /// define storage types
     using array  = memory::device_vector<value_type>;

--- a/src/backends/multicore/fvm.hpp
+++ b/src/backends/multicore/fvm.hpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include <backends/event.hpp>
+#include <backends/fvm_types.hpp>
 #include <common_types.hpp>
 #include <event_queue.hpp>
 #include <mechanism.hpp>
@@ -28,8 +29,8 @@ struct backend {
     }
 
     /// define the real and index types
-    using value_type = double;
-    using size_type  = nest::mc::cell_lid_type;
+    using value_type = fvm_value_type;
+    using size_type  = fvm_size_type;
 
     /// define storage types
     using array  = memory::host_vector<value_type>;

--- a/src/fvm_multicell.hpp
+++ b/src/fvm_multicell.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include <algorithms.hpp>
+#include <backends/fvm_types.hpp>
 #include <cell.hpp>
 #include <compartment.hpp>
 #include <event_queue.hpp>
@@ -48,10 +49,10 @@ public:
     using backend = Backend;
 
     /// the real number type
-    using value_type = typename backend::value_type;
+    using value_type = fvm_value_type;
 
     /// the integral index type
-    using size_type = typename backend::size_type;
+    using size_type = fvm_size_type;
 
     /// the container used for values
     using array = typename backend::array;


### PR DESCRIPTION
* Add `backends/fvm_types.hpp` as a single location for shared types across multicore and gpu fvm implementations.
* Use the `fvm_value_type` and `fvm_size_type` defined in `fvm_types.hpp` for the corresponding class-local `value_type` and `size_type` definitions.