### PR TITLE
Stand alone CUDA compilation for threshold_watcher in gpu backend

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,7 @@ set(CUDA_SOURCES
     backends/gpu/fvm.cu
     backends/gpu/multi_event_stream.cu
     backends/gpu/fill.cu
+    backends/gpu/kernels/test_thresholds.cu
 )
 
 # The cell_group_factory acts like an interface between the

--- a/src/backends/fvm_types.hpp
+++ b/src/backends/fvm_types.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <common_types.hpp>
+
+// Basic types shared across FVM implementations/backends.
+
+namespace nest {
+namespace mc {
+
+using fvm_value_type = double;
+using fvm_size_type = cell_local_size_type;
+
+} // namespace mc
+} // namespace nest

--- a/src/backends/gpu/fvm.hpp
+++ b/src/backends/gpu/fvm.hpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include <backends/event.hpp>
+#include <backends/fvm_types.hpp>
 #include <common_types.hpp>
 #include <mechanism.hpp>
 #include <memory/memory.hpp>
@@ -26,8 +27,8 @@ struct backend {
     }
 
     /// define the real and index types
-    using value_type = double;
-    using size_type  = nest::mc::cell_lid_type;
+    using value_type = fvm_value_type;
+    using size_type  = fvm_size_type;
 
     /// define storage types
     using array  = memory::device_vector<value_type>;

--- a/src/backends/gpu/fvm.hpp
+++ b/src/backends/gpu/fvm.hpp
@@ -86,8 +86,7 @@ struct backend {
         return mech_map_.count(name)>0;
     }
 
-    using threshold_watcher =
-        nest::mc::gpu::threshold_watcher<value_type, size_type>;
+    using threshold_watcher = nest::mc::gpu::threshold_watcher;
 
     // perform min/max reductions on 'array' type
     template <typename V>

--- a/src/backends/gpu/kernels/detail.hpp
+++ b/src/backends/gpu/kernels/detail.hpp
@@ -48,8 +48,8 @@ constexpr inline unsigned block_count(unsigned n, unsigned block_size) {
 
 // The smallest size of a buffer required to store n items in such that the
 // buffer has size that is a multiple of block_dim.
-constexpr inline unsigned padded_size (unsigned n, unsigned block_dim) {
-    return n%block_dim ? n+block_dim-(n%block_dim): n;
+constexpr inline unsigned padded_size(unsigned n, unsigned block_dim) {
+    return block_dim*block_count(n, block_dim);
 }
 
 // Placeholders to use for mark padded locations in data structures that use

--- a/src/backends/gpu/kernels/stack.hpp
+++ b/src/backends/gpu/kernels/stack.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "../stack_common.hpp"
+
+namespace nest {
+namespace mc {
+namespace gpu {
+
+template <typename T>
+__device__
+void push_back(stack_base<T>& s, const T& value) {
+    // Atomically increment the size counter. The atomicAdd returns
+    // the value of size before the increment, which is the location
+    // at which this thread can store value.
+    unsigned position = atomicAdd(&(s.size), 1u);
+
+    // It is possible that size>capacity. In this case, only capacity
+    // entries are stored, and additional values are lost. The size
+    // contains the total number of attempts to push.
+    if (position<s.capacity) {
+        s.data[position] = value;
+    }
+}
+
+} // namespace gpu
+} // namespace mc
+} // namespace nest

--- a/src/backends/gpu/kernels/stack.hpp
+++ b/src/backends/gpu/kernels/stack.hpp
@@ -9,20 +9,20 @@ namespace gpu {
 template <typename T>
 __device__
 void push_back(stack_storage<T>& s, const T& value) {
-    // Atomically increment the size counter. The atomicAdd returns
-    // the value of size before the increment, which is the location
+    // Atomically increment the stores counter. The atomicAdd returns
+    // the value of stores before the increment, which is the location
     // at which this thread can store value.
-    unsigned position = atomicAdd(&(s.size), 1u);
+    unsigned position = atomicAdd(&(s.stores), 1u);
 
-    // It is possible that size>capacity. In this case, only capacity
-    // entries are stored, and additional values are lost. The size
+    // It is possible that stores>capacity. In this case, only capacity
+    // entries are stored, and additional values are lost. The stores
     // contains the total number of attempts to push.
     if (position<s.capacity) {
         s.data[position] = value;
     }
 
-    // Note: there are no guards against s.size overflowing: in which
-    // case the size counter would start again from 0, and values would
+    // Note: there are no guards against s.stores overflowing: in which
+    // case the stores counter would start again from 0, and values would
     // be overwritten from the front of the stack.
 }
 

--- a/src/backends/gpu/kernels/stack.hpp
+++ b/src/backends/gpu/kernels/stack.hpp
@@ -8,7 +8,7 @@ namespace gpu {
 
 template <typename T>
 __device__
-void push_back(stack_base<T>& s, const T& value) {
+void push_back(stack_storage<T>& s, const T& value) {
     // Atomically increment the size counter. The atomicAdd returns
     // the value of size before the increment, which is the location
     // at which this thread can store value.
@@ -20,6 +20,10 @@ void push_back(stack_base<T>& s, const T& value) {
     if (position<s.capacity) {
         s.data[position] = value;
     }
+
+    // Note: there are no guards against s.size overflowing: in which
+    // case the size counter would start again from 0, and values would
+    // be overwritten from the front of the stack.
 }
 
 } // namespace gpu

--- a/src/backends/gpu/kernels/test_thresholds.cu
+++ b/src/backends/gpu/kernels/test_thresholds.cu
@@ -21,7 +21,7 @@ __global__
 void test_thresholds_kernel(
     const fvm_size_type* cv_to_cell, const fvm_value_type* t_after, const fvm_value_type* t_before,
     int size,
-    stack_base<threshold_crossing>& stack,
+    stack_storage<threshold_crossing>& stack,
     fvm_size_type* is_crossed, fvm_value_type* prev_values,
     const fvm_size_type* cv_index, const fvm_value_type* values, const fvm_value_type* thresholds)
 {
@@ -64,7 +64,7 @@ void test_thresholds_kernel(
 void test_thresholds(
     const fvm_size_type* cv_to_cell, const fvm_value_type* t_after, const fvm_value_type* t_before,
     int size,
-    stack_base<threshold_crossing>& stack,
+    stack_storage<threshold_crossing>& stack,
     fvm_size_type* is_crossed, fvm_value_type* prev_values,
     const fvm_size_type* cv_index, const fvm_value_type* values, const fvm_value_type* thresholds)
 {

--- a/src/backends/gpu/kernels/test_thresholds.cu
+++ b/src/backends/gpu/kernels/test_thresholds.cu
@@ -1,0 +1,79 @@
+#include <backends/fvm_types.hpp>
+
+#include "detail.hpp"
+#include "stack.hpp"
+
+namespace nest {
+namespace mc {
+namespace gpu {
+
+/// kernel used to test for threshold crossing test code.
+/// params:
+///     t       : current time (ms)
+///     t_prev  : time of last test (ms)
+///     size    : number of values to test
+///     is_crossed  : crossing state at time t_prev (true or false)
+///     prev_values : values at sample points (see index) sampled at t_prev
+///     index      : index with locations in values to test for crossing
+///     values     : values at t_prev
+///     thresholds : threshold values to watch for crossings
+__global__
+void test_thresholds_kernel(
+    const fvm_size_type* cv_to_cell, const fvm_value_type* t_after, const fvm_value_type* t_before,
+    int size,
+    stack_base<threshold_crossing>& stack,
+    fvm_size_type* is_crossed, fvm_value_type* prev_values,
+    const fvm_size_type* cv_index, const fvm_value_type* values, const fvm_value_type* thresholds)
+{
+    int i = threadIdx.x + blockIdx.x*blockDim.x;
+
+    bool crossed = false;
+    float crossing_time;
+
+    if (i<size) {
+        // Test for threshold crossing
+        const auto cv     = cv_index[i];
+        const auto cell   = cv_to_cell[cv];
+        const auto v_prev = prev_values[i];
+        const auto v      = values[cv];
+        const auto thresh = thresholds[i];
+
+        if (!is_crossed[i]) {
+            if (v>=thresh) {
+                // The threshold has been passed, so estimate the time using
+                // linear interpolation
+                auto pos = (thresh - v_prev)/(v - v_prev);
+                crossing_time = impl::lerp(t_before[cell], t_after[cell], pos);
+
+                is_crossed[i] = 1;
+                crossed = true;
+            }
+        }
+        else if (v<thresh) {
+            is_crossed[i]=0;
+        }
+
+        prev_values[i] = v;
+    }
+
+    if (crossed) {
+        push_back(stack, {fvm_size_type(i), crossing_time});
+    }
+}
+
+void test_thresholds(
+    const fvm_size_type* cv_to_cell, const fvm_value_type* t_after, const fvm_value_type* t_before,
+    int size,
+    stack_base<threshold_crossing>& stack,
+    fvm_size_type* is_crossed, fvm_value_type* prev_values,
+    const fvm_size_type* cv_index, const fvm_value_type* values, const fvm_value_type* thresholds)
+{
+    constexpr int block_dim = 128;
+    const int grid_dim = impl::block_count(size, block_dim);
+    test_thresholds_kernel<<<grid_dim, block_dim>>>(
+        cv_to_cell, t_after, t_before, size, stack, is_crossed, prev_values, cv_index, values, thresholds);
+}
+
+} // namespace gpu
+} // namespace mc
+} // namespace nest

--- a/src/backends/gpu/kernels/test_thresholds.hpp
+++ b/src/backends/gpu/kernels/test_thresholds.hpp
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <backends/fvm_types.hpp>
+
+#include "../stack_common.hpp"
+#include "../stack.hpp"
+
 namespace nest {
 namespace mc {
 namespace gpu {
@@ -14,14 +19,14 @@ namespace gpu {
 ///     index      : index with locations in values to test for crossing
 ///     values     : values at t_prev
 ///     thresholds : threshold values to watch for crossings
-template <typename T, typename I, typename Stack>
 __global__
+static
 void test_thresholds(
-    const I* cv_to_cell, const T* t_after, const T* t_before,
+    const fvm_size_type* cv_to_cell, const fvm_value_type* t_after, const fvm_value_type* t_before,
     int size,
-    Stack& stack,
-    I* is_crossed, T* prev_values,
-    const I* cv_index, const T* values, const T* thresholds)
+    stack_base<threshold_crossing>& stack,
+    fvm_size_type* is_crossed, fvm_value_type* prev_values,
+    const fvm_size_type* cv_index, const fvm_value_type* values, const fvm_value_type* thresholds)
 {
     int i = threadIdx.x + blockIdx.x*blockDim.x;
 
@@ -55,7 +60,7 @@ void test_thresholds(
     }
 
     if (crossed) {
-        stack.push_back({I(i), crossing_time});
+        //stack.push_back({fvm_size_type(i), crossing_time});
     }
 }
 

--- a/src/backends/gpu/kernels/test_thresholds.hpp
+++ b/src/backends/gpu/kernels/test_thresholds.hpp
@@ -11,7 +11,7 @@ namespace gpu {
 extern void test_thresholds(
     const fvm_size_type* cv_to_cell, const fvm_value_type* t_after, const fvm_value_type* t_before,
     int size,
-    stack_base<threshold_crossing>& stack,
+    stack_storage<threshold_crossing>& stack,
     fvm_size_type* is_crossed, fvm_value_type* prev_values,
     const fvm_size_type* cv_index, const fvm_value_type* values, const fvm_value_type* thresholds);
 

--- a/src/backends/gpu/kernels/test_thresholds.hpp
+++ b/src/backends/gpu/kernels/test_thresholds.hpp
@@ -2,67 +2,18 @@
 
 #include <backends/fvm_types.hpp>
 
-#include "../stack_common.hpp"
-#include "../stack.hpp"
+#include "stack.hpp"
 
 namespace nest {
 namespace mc {
 namespace gpu {
 
-/// kernel used to test for threshold crossing test code.
-/// params:
-///     t       : current time (ms)
-///     t_prev  : time of last test (ms)
-///     size    : number of values to test
-///     is_crossed  : crossing state at time t_prev (true or false)
-///     prev_values : values at sample points (see index) sampled at t_prev
-///     index      : index with locations in values to test for crossing
-///     values     : values at t_prev
-///     thresholds : threshold values to watch for crossings
-__global__
-static
-void test_thresholds(
+extern void test_thresholds(
     const fvm_size_type* cv_to_cell, const fvm_value_type* t_after, const fvm_value_type* t_before,
     int size,
     stack_base<threshold_crossing>& stack,
     fvm_size_type* is_crossed, fvm_value_type* prev_values,
-    const fvm_size_type* cv_index, const fvm_value_type* values, const fvm_value_type* thresholds)
-{
-    int i = threadIdx.x + blockIdx.x*blockDim.x;
-
-    bool crossed = false;
-    float crossing_time;
-
-    if (i<size) {
-        // Test for threshold crossing
-        const auto cv     = cv_index[i];
-        const auto cell   = cv_to_cell[cv];
-        const auto v_prev = prev_values[i];
-        const auto v      = values[cv];
-        const auto thresh = thresholds[i];
-
-        if (!is_crossed[i]) {
-            if (v>=thresh) {
-                // The threshold has been passed, so estimate the time using
-                // linear interpolation
-                auto pos = (thresh - v_prev)/(v - v_prev);
-                crossing_time = impl::lerp(t_before[cell], t_after[cell], pos);
-
-                is_crossed[i] = 1;
-                crossed = true;
-            }
-        }
-        else if (v<thresh) {
-            is_crossed[i]=0;
-        }
-
-        prev_values[i] = v;
-    }
-
-    if (crossed) {
-        //stack.push_back({fvm_size_type(i), crossing_time});
-    }
-}
+    const fvm_size_type* cv_index, const fvm_value_type* values, const fvm_value_type* thresholds);
 
 } // namespace gpu
 } // namespace mc

--- a/src/backends/gpu/stack.hpp
+++ b/src/backends/gpu/stack.hpp
@@ -34,7 +34,7 @@ class stack {
     storage_type* create_storage(unsigned n) {
         auto p = allocator<storage_type>().allocate(1);
         p->capacity = n;
-        p->size = 0;
+        p->stores = 0;
         p->data = allocator<value_type>().allocate(n);
         return p;
     }
@@ -62,23 +62,23 @@ public:
     }
 
     void clear() {
-        storage_->size = 0u;
+        storage_->stores = 0u;
     }
 
     // The number of items that have been pushed back on the stack.
     // This may exceed capacity, which indicates that the caller attempted
     // to push back more values than there was space to store.
     unsigned pushes() const {
-        return storage_->size;
+        return storage_->stores;
     }
 
     bool overflow() const {
-        return storage_->size>capacity();
+        return storage_->stores>capacity();
     }
 
     // The number of values stored in the stack.
     unsigned size() const {
-        return std::min(storage_->size, storage_->capacity);
+        return std::min(storage_->stores, storage_->capacity);
     }
 
     // The maximum number of items that can be stored in the stack.

--- a/src/backends/gpu/stack.hpp
+++ b/src/backends/gpu/stack.hpp
@@ -28,82 +28,92 @@ class stack {
     template <typename U>
     using allocator = memory::managed_allocator<U>;
 
-    using base_type = stack_base<value_type>;
-    base_type* base_;
+    using storage_type = stack_storage<value_type>;
+    storage_type* storage_;
+
+    storage_type* create_storage(unsigned n) {
+        auto p = allocator<storage_type>().allocate(1);
+        p->capacity = n;
+        p->size = 0;
+        p->data = allocator<value_type>().allocate(n);
+        return p;
+    }
 
 public:
-    stack& operator==(const stack& other) = delete;
+    stack& operator=(const stack& other) = delete;
     stack(const stack& other) = delete;
 
-    stack(stack&& other) {
-        std::swap(base_, other.base_);
+    stack(): storage_(create_storage(0)) {}
+
+    stack(stack&& other): storage_(create_storage(0)) {
+        std::swap(storage_, other.storage_);
     }
 
     stack& operator=(stack&& other) {
-        std::swap(base_, other.base_);
+        std::swap(storage_, other.storage_);
         return *this;
     }
 
-    stack(unsigned capacity) {
-        base_ = allocator<base_type>().allocate(1);
-        base_->capacity = capacity;
-        base_->size = 0;
-        base_->data = allocator<value_type>().allocate(capacity);
-    }
-
-    stack(): stack(0) {}
+    explicit stack(unsigned capacity): storage_(create_storage(capacity)) {}
 
     ~stack() {
-        if (base_) {
-            allocator<value_type>().deallocate(base_->data, base_->capacity);
-            allocator<base_type>().deallocate(base_, 1);
-        }
+        allocator<value_type>().deallocate(storage_->data, storage_->capacity);
+        allocator<storage_type>().deallocate(storage_, 1);
     }
 
     void clear() {
-        base_->size = 0;
+        storage_->size = 0u;
     }
 
     // The number of items that have been pushed back on the stack.
-    // size may exceed capacity, which indicates that the caller attempted
+    // This may exceed capacity, which indicates that the caller attempted
     // to push back more values than there was space to store.
+    unsigned pushes() const {
+        return storage_->size;
+    }
+
+    bool is_overflowed() const {
+        return storage_->size>capacity();
+    }
+
+    // The number of values stored in the stack.
     unsigned size() const {
-        return base_->size;
+        return std::min(storage_->size, storage_->capacity);
     }
 
     // The maximum number of items that can be stored in the stack.
     unsigned capacity() const {
-        return base_->capacity;
+        return storage_->capacity;
     }
 
-    base_type& base() {
-        return *base_;
+    storage_type& storage() {
+        return *storage_;
     }
 
     value_type& operator[](unsigned i) {
-        EXPECTS(i<base_->size && i<base_->capacity);
-        return base_->data[i];
+        EXPECTS(i<size());
+        return storage_->data[i];
     }
 
     value_type& operator[](unsigned i) const {
-        EXPECTS(i<base_->size && i<base_->capacity);
-        return base_->data[i];
+        EXPECTS(i<size());
+        return storage_->data[i];
     }
 
     value_type* begin() {
-        return base_->data;
+        return storage_->data;
     }
     const value_type* begin() const {
-        return base_->data;
+        return storage_->data;
     }
 
     value_type* end() {
         // Take care of the case where size>capacity.
-        return base_->data + std::min(base_->size, base_->capacity);
+        return storage_->data + size();
     }
     const value_type* end() const {
         // Take care of the case where size>capacity.
-        return base_->data + std::min(base_->size, base_->capacity);
+        return storage_->data + size();
     }
 };
 

--- a/src/backends/gpu/stack_common.hpp
+++ b/src/backends/gpu/stack_common.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "backends/fvm_types.hpp"
+#include <backends/fvm_types.hpp>
 
 namespace nest {
 namespace mc {
@@ -28,21 +28,6 @@ struct stack_base {
 
     // Memory containing the value buffer
     value_type* data;
-
-    __device__
-    void push_back(const value_type& value) {
-        // Atomically increment the size_ counter. The atomicAdd returns
-        // the value of size_ before the increment, which is the location
-        // at which this thread can store value.
-        unsigned position = atomicAdd(&size, 1u);
-
-        // It is possible that size_>capacity_. In this case, only capacity_
-        // entries are stored, and additional values are lost. The size_
-        // will contain the total number of attempts to push,
-        if (position<capacity) {
-            data[position] = value;
-        }
-    }
 };
 
 

--- a/src/backends/gpu/stack_common.hpp
+++ b/src/backends/gpu/stack_common.hpp
@@ -27,8 +27,10 @@ struct stack_storage {
     // The number of items of type value_type that can be stored in the stack
     unsigned capacity;
 
-    // The number of items that have been stored
-    unsigned size;
+    // The number of items that have been stored.
+    // This may exceed capacity if more stores were attempted than it is
+    // possible to store, in which case only the first capacity values are valid.
+    unsigned stores;
 
     // Memory containing the value buffer
     value_type* data;

--- a/src/backends/gpu/stack_common.hpp
+++ b/src/backends/gpu/stack_common.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "backends/fvm_types.hpp"
+
+namespace nest {
+namespace mc {
+namespace gpu {
+
+/// stores a single crossing event
+struct threshold_crossing {
+    fvm_size_type index;    // index of variable
+    fvm_value_type time;    // time of crossing
+
+    friend bool operator==(threshold_crossing l, threshold_crossing r) {
+        return l.index==r.index && l.time==r.time;
+    }
+};
+
+template <typename T>
+struct stack_base {
+    using value_type = T;
+
+    // The number of items of type value_type that can be stored in the stack
+    unsigned capacity;
+
+    // The number of items that have been stored
+    unsigned size;
+
+    // Memory containing the value buffer
+    value_type* data;
+
+    __device__
+    void push_back(const value_type& value) {
+        // Atomically increment the size_ counter. The atomicAdd returns
+        // the value of size_ before the increment, which is the location
+        // at which this thread can store value.
+        unsigned position = atomicAdd(&size, 1u);
+
+        // It is possible that size_>capacity_. In this case, only capacity_
+        // entries are stored, and additional values are lost. The size_
+        // will contain the total number of attempts to push,
+        if (position<capacity) {
+            data[position] = value;
+        }
+    }
+};
+
+
+} // namespace gpu
+} // namespace mc
+} // namespace nest

--- a/src/backends/gpu/stack_common.hpp
+++ b/src/backends/gpu/stack_common.hpp
@@ -6,7 +6,7 @@ namespace nest {
 namespace mc {
 namespace gpu {
 
-/// stores a single crossing event
+// stores a single crossing event
 struct threshold_crossing {
     fvm_size_type index;    // index of variable
     fvm_value_type time;    // time of crossing
@@ -16,8 +16,12 @@ struct threshold_crossing {
     }
 };
 
+// Concrete storage of gpu stack datatype.
+// The stack datatype resides in host memory, and holds a pointer to the
+// stack_storage in managed memory, which can be accessed by both host and
+// gpu code.
 template <typename T>
-struct stack_base {
+struct stack_storage {
     using value_type = T;
 
     // The number of items of type value_type that can be stored in the stack

--- a/src/backends/gpu/threshold_watcher.hpp
+++ b/src/backends/gpu/threshold_watcher.hpp
@@ -94,9 +94,7 @@ public:
     /// crossed since current time t, and the last time the test was
     /// performed.
     void test() {
-        constexpr int block_dim = 128;
-        const int grid_dim = (size()+block_dim-1)/block_dim;
-        test_thresholds<<<grid_dim, block_dim>>>(
+        test_thresholds(
             cv_to_cell_.data(), t_after_.data(), t_before_.data(),
             size(),
             stack_.base(),
@@ -105,7 +103,12 @@ public:
 
         // Check that the number of spikes has not exceeded
         // the capacity of the stack.
+        // ATTENTION: requires cudaDeviceSynchronize to avoid simultaneous
+        // host-device managed memory access.
+#ifdef NMC_HAVE_ASSERTIONS
+        cudaDeviceSynchronize();
         EXPECTS(stack_.size() <= stack_.capacity());
+#endif
     }
 
     /// the number of threashold values that are being monitored

--- a/src/backends/gpu/threshold_watcher.hpp
+++ b/src/backends/gpu/threshold_watcher.hpp
@@ -6,6 +6,7 @@
 
 #include "managed_ptr.hpp"
 #include "stack.hpp"
+#include "backends/fvm_types.hpp"
 #include "kernels/test_thresholds.hpp"
 
 namespace nest {
@@ -14,26 +15,22 @@ namespace gpu {
 
 /// threshold crossing logic
 /// used as part of spike detection back end
-template <typename T, typename I>
 class threshold_watcher {
 public:
-    using value_type = T;
-    using size_type = I;
+    using value_type = fvm_value_type;
+    using size_type = fvm_size_type;
 
-    using array = memory::device_vector<T>;
-    using iarray = memory::device_vector<I>;
+    using array = memory::device_vector<value_type>;
+    using iarray = memory::device_vector<size_type>;
     using const_view = typename array::const_view_type;
     using const_iview = typename iarray::const_view_type;
-
-    /// stores a single crossing event
-    struct threshold_crossing {
-        size_type index;    // index of variable
-        value_type time;    // time of crossing
-    };
 
     using stack_type = stack<threshold_crossing>;
 
     threshold_watcher() = default;
+
+    threshold_watcher(threshold_watcher&& other) = default;
+    threshold_watcher& operator=(threshold_watcher&& other) = default;
 
     threshold_watcher(
             const_iview vec_ci,
@@ -51,7 +48,7 @@ public:
         thresholds_(memory::make_const_view(thresh)),
         prev_values_(values),
         is_crossed_(size()),
-        stack_(make_managed_ptr<stack_type>(10*size()))
+        stack_(10*size())
     {
         reset();
     }
@@ -59,7 +56,7 @@ public:
     /// Remove all stored crossings that were detected in previous calls
     /// to test()
     void clear_crossings() {
-        stack_->clear();
+        stack_.clear();
     }
 
     /// Reset state machine for each detector.
@@ -89,7 +86,7 @@ public:
     }
 
     const std::vector<threshold_crossing> crossings() const {
-        return std::vector<threshold_crossing>(stack_->begin(), stack_->end());
+        return std::vector<threshold_crossing>(stack_.begin(), stack_.end());
     }
 
     /// Tests each target for changed threshold state.
@@ -102,13 +99,13 @@ public:
         test_thresholds<<<grid_dim, block_dim>>>(
             cv_to_cell_.data(), t_after_.data(), t_before_.data(),
             size(),
-            *stack_,
+            stack_.base(),
             is_crossed_.data(), prev_values_.data(),
             cv_index_.data(), values_.data(), thresholds_.data());
 
         // Check that the number of spikes has not exceeded
         // the capacity of the stack.
-        EXPECTS(stack_->size() <= stack_->capacity());
+        EXPECTS(stack_.size() <= stack_.capacity());
     }
 
     /// the number of threashold values that are being monitored
@@ -131,7 +128,7 @@ private:
     array prev_values_;         // values at previous sample time: on gpu
     iarray is_crossed_;         // bool flag for state of each watch: on gpu
 
-    managed_ptr<stack_type> stack_;
+    stack_type stack_;
 };
 
 } // namespace gpu

--- a/src/backends/multicore/fvm.hpp
+++ b/src/backends/multicore/fvm.hpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include <backends/event.hpp>
+#include <backends/fvm_types.hpp>
 #include <common_types.hpp>
 #include <event_queue.hpp>
 #include <mechanism.hpp>
@@ -28,8 +29,8 @@ struct backend {
     }
 
     /// define the real and index types
-    using value_type = double;
-    using size_type  = nest::mc::cell_lid_type;
+    using value_type = fvm_value_type;
+    using size_type  = fvm_size_type;
 
     /// define storage types
     using array  = memory::host_vector<value_type>;

--- a/src/communication/communicator.hpp
+++ b/src/communication/communicator.hpp
@@ -1,15 +1,16 @@
 #pragma once
 
 #include <algorithm>
-#include <iostream>
-#include <vector>
-#include <random>
 #include <functional>
+#include <iostream>
+#include <random>
+#include <utility>
+#include <vector>
 
 #include <algorithms.hpp>
 #include <common_types.hpp>
-#include <connection.hpp>
 #include <communication/gathered_vector.hpp>
+#include <connection.hpp>
 #include <domain_decomposition.hpp>
 #include <event_queue.hpp>
 #include <recipe.hpp>
@@ -55,7 +56,8 @@ public:
 
         // For caching information about each cell
         struct gid_info {
-            using connection_list = decltype(rec.connections_on(0));
+            //using connection_list = decltype(rec.connections_on(0));
+            using connection_list = decltype(std::declval<recipe>().connections_on(0));
             cell_gid_type gid;
             cell_gid_type local_group;
             connection_list conns;

--- a/src/communication/communicator.hpp
+++ b/src/communication/communicator.hpp
@@ -56,7 +56,6 @@ public:
 
         // For caching information about each cell
         struct gid_info {
-            //using connection_list = decltype(rec.connections_on(0));
             using connection_list = decltype(std::declval<recipe>().connections_on(0));
             cell_gid_type gid;
             cell_gid_type local_group;

--- a/src/fvm_multicell.hpp
+++ b/src/fvm_multicell.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include <algorithms.hpp>
+#include <backends/fvm_types.hpp>
 #include <cell.hpp>
 #include <compartment.hpp>
 #include <event_queue.hpp>
@@ -48,10 +49,10 @@ public:
     using backend = Backend;
 
     /// the real number type
-    using value_type = typename backend::value_type;
+    using value_type = fvm_value_type;
 
     /// the integral index type
-    using size_type = typename backend::size_type;
+    using size_type = fvm_size_type;
 
     /// the container used for values
     using array = typename backend::array;

--- a/src/memory/allocator.hpp
+++ b/src/memory/allocator.hpp
@@ -148,7 +148,7 @@ namespace impl {
                 void* ptr = reinterpret_cast<void *>
                                 (aligned_malloc<char, Alignment>(size));
 
-                if(ptr == nullptr) {
+                if (!ptr) {
                     return nullptr;
                 }
 
@@ -166,7 +166,7 @@ namespace impl {
             }
 
             void free_policy(void *ptr) {
-                if(ptr == nullptr) {
+                if (!ptr) {
                     return;
                 }
                 cudaHostUnregister(ptr);
@@ -189,12 +189,12 @@ namespace impl {
             static_assert(1024%Alignment==0, "CUDA managed memory is always aligned on 1024 byte boundaries");
 
             void* allocate_policy(std::size_t n) {
-                if (n==0u) {
+                if (!n) {
                     return nullptr;
                 }
                 void* ptr;
                 auto status = cudaMallocManaged(&ptr, n);
-                if(status != cudaSuccess) {
+                if (status != cudaSuccess) {
                     LOG_ERROR("memory:: unable to allocate managed memory");
                     ptr = nullptr;
                 }
@@ -283,15 +283,14 @@ public:
     }
 
     pointer allocate(size_type cnt, typename std::allocator<void>::const_pointer = 0) {
-        pointer p = reinterpret_cast<T*>(allocate_policy(cnt*sizeof(T)));
-        //std::cout << "aaa " << p << " : " << cnt << " " << util::type_printer<allocator>::print() << "\n";
-        return p;
-        //return reinterpret_cast<T*>(allocate_policy(cnt*sizeof(T)));
+        if (cnt) {
+            return reinterpret_cast<T*>(allocate_policy(cnt*sizeof(T)));
+        }
+        return nullptr;
     }
 
     void deallocate(pointer p, size_type cnt) {
-        //std::cout << "fff " << p << " : " << cnt << " " << util::type_printer<allocator>::print() << "\n";
-        if( p!=nullptr ) {
+        if (p) {
             free_policy(p);
         }
     }

--- a/src/memory/definitions.hpp
+++ b/src/memory/definitions.hpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <sstream>
+#include <typeinfo>
 
 namespace nest {
 namespace mc {
@@ -67,7 +68,7 @@ namespace util {
     template <typename T>
     struct type_printer{
         static std::string print() {
-            return std::string("T");
+            return typeid(T).name();
         }
     };
 

--- a/tests/unit/test_gpu_stack.cu
+++ b/tests/unit/test_gpu_stack.cu
@@ -1,5 +1,6 @@
 #include "../gtest.h"
 
+#include <backends/gpu/kernels/stack.hpp>
 #include <backends/gpu/stack.hpp>
 #include <backends/gpu/managed_ptr.hpp>
 
@@ -18,9 +19,9 @@ TEST(stack, construction) {
 namespace kernels {
     template <typename F>
     __global__
-    void push_back(gpu::stack<int>& s, F f) {
+    void push_back(gpu::stack_base<int>& s, F f) {
         if (f(threadIdx.x)) {
-            s.push_back(threadIdx.x);
+            nest::mc::gpu::push_back(s, int(threadIdx.x));
         }
     }
 
@@ -52,28 +53,29 @@ TEST(stack, push_back) {
 
     const unsigned n = 10;
     EXPECT_TRUE(n%2 == 0); // require n is even for tests to work
-    auto s = gpu::make_managed_ptr<stack>(n);
+    auto s = stack(n);
+    auto& sbase = s.base();
 
-    kernels::push_back<<<1, n>>>(*s, kernels::all_ftor());
+    kernels::push_back<<<1, n>>>(sbase, kernels::all_ftor());
     cudaDeviceSynchronize();
-    EXPECT_EQ(n, s->size());
-    for (auto i=0; i<int(s->size()); ++i) {
-        EXPECT_EQ(i, (*s)[i]);
+    EXPECT_EQ(n, s.size());
+    for (auto i=0; i<int(s.size()); ++i) {
+        EXPECT_EQ(i, s[i]);
     }
 
-    s->clear();
-    kernels::push_back<<<1, n>>>(*s, kernels::even_ftor());
+    s.clear();
+    kernels::push_back<<<1, n>>>(sbase, kernels::even_ftor());
     cudaDeviceSynchronize();
-    EXPECT_EQ(n/2, s->size());
-    for (auto i=0; i<int(s->size())/2; ++i) {
-        EXPECT_EQ(2*i, (*s)[i]);
+    EXPECT_EQ(n/2, s.size());
+    for (auto i=0; i<int(s.size())/2; ++i) {
+        EXPECT_EQ(2*i, s[i]);
     }
 
-    s->clear();
-    kernels::push_back<<<1, n>>>(*s, kernels::odd_ftor());
+    s.clear();
+    kernels::push_back<<<1, n>>>(sbase, kernels::odd_ftor());
     cudaDeviceSynchronize();
-    EXPECT_EQ(n/2, s->size());
-    for (auto i=0; i<int(s->size())/2; ++i) {
-        EXPECT_EQ(2*i+1, (*s)[i]);
+    EXPECT_EQ(n/2, s.size());
+    for (auto i=0; i<int(s.size())/2; ++i) {
+        EXPECT_EQ(2*i+1, s[i]);
     }
 }

--- a/tests/unit/test_spikes.cpp
+++ b/tests/unit/test_spikes.cpp
@@ -18,7 +18,6 @@ using backend = USE_BACKEND;
 #endif
 
 TEST(spikes, threshold_watcher) {
-    using backend = multicore::backend;
     using size_type = backend::size_type;
     using value_type = backend::value_type;
     using array = backend::array;
@@ -61,7 +60,7 @@ TEST(spikes, threshold_watcher) {
 
     // test again at t=1, with unchanged values
     //  - nothing should change
-    util::fill(time_after, 1.);
+    memory::fill(time_after, 1.);
     watch.test();
     EXPECT_FALSE(watch.is_crossed(0));
     EXPECT_TRUE(watch.is_crossed(1));
@@ -72,7 +71,7 @@ TEST(spikes, threshold_watcher) {
     //  - 2nd watch should now stop spiking
     memory::fill(values, 0.);
     memory::copy(time_after, time_before);
-    util::fill(time_after, 2.);
+    memory::fill(time_after, 2.);
     watch.test();
     EXPECT_FALSE(watch.is_crossed(0));
     EXPECT_FALSE(watch.is_crossed(1));
@@ -100,7 +99,7 @@ TEST(spikes, threshold_watcher) {
     //  - all watches should stop spiking
     memory::fill(values, 0.);
     memory::copy(time_after, time_before);
-    util::fill(time_after, 4.);
+    memory::fill(time_after, 4.);
     watch.test();
     EXPECT_FALSE(watch.is_crossed(0));
     EXPECT_FALSE(watch.is_crossed(1));
@@ -111,7 +110,7 @@ TEST(spikes, threshold_watcher) {
     //  - watch 3 should be spiking
     values[index[2]] = 6.;
     memory::copy(time_after, time_before);
-    util::fill(time_after, 5.);
+    memory::fill(time_after, 5.);
     watch.test();
     EXPECT_FALSE(watch.is_crossed(0));
     EXPECT_FALSE(watch.is_crossed(1));
@@ -144,7 +143,7 @@ TEST(spikes, threshold_watcher) {
     //
     memory::fill(values, 0);
     values[index[0]] = 10.; // first watch should be intialized to spiking state
-    util::fill(time_before, 0.);
+    memory::fill(time_before, 0.);
     watch.reset();
     EXPECT_EQ(watch.crossings().size(), 0u);
     EXPECT_TRUE(watch.is_crossed(0));


### PR DESCRIPTION
Refactor the threshold_watcher and stack data structures in the gpu backend so that they are amenable to separable compilation. To wit:
- The `gpu::stack<T>` type had both `__host__` and `__device__` member functions, to allow dual use:
    - make `gpu::stack<T>` have a host-only interface that wraps a POD type `gpu::stack_base<T>`
    - implement a `push_back(stack_base, value)` method in `backends/gpu/kernels/stack.hpp` that is visible only to device code.
- The `test_thresholds` kernel was moved from a header file to a .cu file that is , and
    - template parameters were removed and the types provided by `backends/fvm_types.hpp` used
    - a simple c function interface, callable from host side code, is defined in `backends/gpu/threshold_common.hpp`
    - the c function is implemented in the cuda code, and is available at link time.
In this manner header files that define simple types and prototypes are used by both host
and CUDA translation units. Hopefully this will allow the use of compilers that don't support
more recent C++ standards for the low-level cuda, with C++14/17 support in the front end.

Also, some small fixes:
- simplify the `gpu::impl::padded_size` function (both to read and in terms of efficiency)
- use `typeid` as the default for pretty-printing types in the memory back end.
- update `test_gpu_stack` unit test to support new gpu stack interface.
- fix bug in `test_spikes` unit test, which was not running the GPU back end in the cuda unit tests.