### PR TITLE
Remove intrinsics unit test that does not compile

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -47,7 +47,7 @@ set(TEST_SOURCES
     test_event_binner.cpp
     test_filter.cpp
     test_fvm_multi.cpp
-    test_intrin.cpp
+    #test_intrin.cpp
     test_mc_cell_group.cpp
     test_lexcmp.cpp
     test_mask_stream.cpp


### PR DESCRIPTION
The unit test for AVX2 intrinsics does not compile with gcc.
This is a quick fix to get master to compile, while the test is fixed.